### PR TITLE
[BUG] Fix use of undeclared identifier 'status‘’

### DIFF
--- a/source/tnn/device/opencl/acc/opencl_cpu_adapter_acc.cc
+++ b/source/tnn/device/opencl/acc/opencl_cpu_adapter_acc.cc
@@ -133,6 +133,7 @@ Status OpenCLCpuAdapterAcc::Reshape(const std::vector<Blob *> &inputs, const std
 }
 
 Status OpenCLCpuAdapterAcc::Forward(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
+    Status status = TNN_OK;
     void* command_queue = nullptr;
     ocl_context_->GetCommandQueue(&command_queue);
     //convert data from opencl to cpu


### PR DESCRIPTION
- branch: master
- macOS
- compile error: `./build_android.sh`

```shell
/Users/code/dl-inference-benchmark/tnn/tnn/source/tnn/device/opencl/acc/opencl_cpu_adapter_acc.cc:169:13: error: use of undeclared identifier 'status'
            status = blob_converter.ConvertFromMat(mat, param, command_queue);
            ^
/Users/code/dl-inference-benchmark/tnn/tnn/source/tnn/device/opencl/acc/opencl_cpu_adapter_acc.cc:175:13: error: use of undeclared identifier 'status'
            status = blob_converter.ConvertFromMat(mat, param, command_queue);
            ^
/Users/code/dl-inference-benchmark/tnn/tnn/source/tnn/device/opencl/acc/opencl_cpu_adapter_acc.cc:179:12: error: use of undeclared identifier 'status'
    return status;
           ^
[ 15%] Building CXX objec
```