### PR TITLE
优化了convert2tnn中的日志输出

### DIFF
--- a/include/tnn/core/macro.h
+++ b/include/tnn/core/macro.h
@@ -154,7 +154,7 @@
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
 #endif
 #ifndef ABS
-#define ABS(x) ((x) > (0) ? (x) : (-x))
+#define ABS(x) ((x) > (0) ? (x) : (-(x)))
 #endif
 
 #if (__arm__ || __aarch64__) && (defined(__ARM_NEON__) || defined(__ARM_NEON))

--- a/source/tnn/device/arm/acc/arm_pow_layer_acc.cc
+++ b/source/tnn/device/arm/acc/arm_pow_layer_acc.cc
@@ -35,7 +35,7 @@ Status ArmPowLayerAcc::DoForward(const std::vector<Blob *> &inputs, const std::v
         float *output_data = reinterpret_cast<float *>(GetBlobHandlePtr(output_blob->GetHandle()));
 
         int pow = std::round(layer_param->exponent);
-        if (ABS(pow - layer_param->exponent) < 0.00001) {
+        if (ABS(pow - layer_param->exponent) < FLT_EPSILON) {
             bool reciprocal = pow < 0;
             if(reciprocal)
                 pow = -pow;

--- a/source/tnn/device/metal/acc/metal_cpu_adapter_acc.mm
+++ b/source/tnn/device/metal/acc/metal_cpu_adapter_acc.mm
@@ -132,7 +132,8 @@ Status MetalCpuAdapterAcc::Reshape(const std::vector<Blob *> &inputs, const std:
 Status MetalCpuAdapterAcc::Forward(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     void* command_queue = nullptr;
     metal_context_->GetCommandQueue(&command_queue);
-    
+
+    Status status = TNN_OK;
     //convert data from metal to cpu
     for(int i = 0; i < inputs.size(); ++i) {
         auto device_input = inputs[i];
@@ -143,19 +144,25 @@ Status MetalCpuAdapterAcc::Forward(const std::vector<Blob *> &inputs, const std:
         MatConvertParam param;
         if(DATA_FORMAT_NCHW == cpu_input->GetBlobDesc().data_format) {
             Mat mat(DEVICE_NAIVE, NCHW_FLOAT, cpu_input->GetBlobDesc().dims, cpu_input->GetHandle().base);
-            blob_converter.ConvertToMat(mat, param, command_queue);
+            status = blob_converter.ConvertToMat(mat, param, command_queue);
+            if (status != TNN_OK) {
+                return status;
+            }
         } else {
             //To optimize, use convert to change format
             Mat mat(DEVICE_NAIVE, NCHW_FLOAT, cpu_input->GetBlobDesc().dims);
-            blob_converter.ConvertToMat(mat, param, command_queue);
+            status = blob_converter.ConvertToMat(mat, param, command_queue);
+            if (status != TNN_OK) {
+                return status;
+            }
             float* src_data = reinterpret_cast<float*>(mat.GetData());
             float* dst_data = reinterpret_cast<float*>(cpu_input->GetHandle().base);
             DataFormatConverter::ConvertFromNCHWToNCHW4Float(src_data, dst_data, dims[0], dims[1], dims[2], dims[3]);
         }
     }
-    
+
     //cpu acc forword
-    auto status = cpu_adapter_acc_->Forward(cpu_blob_in_, cpu_blob_out_);
+    status = cpu_adapter_acc_->Forward(cpu_blob_in_, cpu_blob_out_);
     if (status != TNN_OK) {
         return status;
     }
@@ -171,6 +178,9 @@ Status MetalCpuAdapterAcc::Forward(const std::vector<Blob *> &inputs, const std:
         if(DATA_FORMAT_NCHW == cpu_output->GetBlobDesc().data_format) {
             Mat mat(DEVICE_NAIVE, NCHW_FLOAT, cpu_output->GetBlobDesc().dims, cpu_output->GetHandle().base);
             status = blob_converter.ConvertFromMat(mat, param, command_queue);
+            if (status != TNN_OK) {
+                return status;
+            }
         } else {
             //To optimize, use convert to change format
             Mat mat(DEVICE_NAIVE, NCHW_FLOAT, dims);
@@ -178,6 +188,9 @@ Status MetalCpuAdapterAcc::Forward(const std::vector<Blob *> &inputs, const std:
             float* dst_data = reinterpret_cast<float*>(mat.GetData());
             DataFormatConverter::ConvertFromNCHW4ToNCHWFloat(src_data, dst_data, dims[0], dims[1], dims[2], dims[3]);
             status = blob_converter.ConvertFromMat(mat, param, command_queue);
+            if (status != TNN_OK) {
+                return status;
+            }
         }
     }
 

--- a/tools/convert2tnn/caffe_converter/caffe2tnn.py
+++ b/tools/convert2tnn/caffe_converter/caffe2tnn.py
@@ -33,6 +33,7 @@ def caffe2onnx(proto_path, model_path, output_path):
 
 def convert(proto_path, model_path, output_dir, version, optimize, half, align=False,
             input_path=None, refer_path=None):
+    logging.info("converter Caffe to ONNX Model\n")
     checker.check_file_exist(proto_path)
     checker.check_file_exist(model_path)
     if output_dir is None:
@@ -44,9 +45,9 @@ def convert(proto_path, model_path, output_dir, version, optimize, half, align=F
     onnx_path = os.path.join(output_dir, proto_name + ".onnx")
 
     if caffe2onnx(proto_path, model_path, onnx_path) is False:
-        logging.info("\nOh No, caff2onnx failed")
+        logging.info("Oh No, caff2onnx failed\n")
     else:
-        logging.info("\ncongratulations! caffe2onnx succeed!")
+        logging.info("congratulations! caffe2onnx succeed!\n")
     if version is None:
         version = "v1.0"
 

--- a/tools/convert2tnn/converter.py
+++ b/tools/convert2tnn/converter.py
@@ -27,6 +27,8 @@ def main():
     parser = args_parser.parse_args()
     args = parser.parse_args()
 
+    logging.info("\n{}  convert model, please wait a moment {}\n".format("-" * 10, "-" * 10))
+
     if args.sub_command == 'onnx2tnn':
         onnx_path = parse_path.parse_path(args.onnx_path)
         output_dir = parse_path.parse_path(args.output_dir)
@@ -43,11 +45,9 @@ def main():
         ref_file = parse_path.parse_path(ref_file)
 
         try:
-            logging.info("{}  convert model  {}" .format("-" * 30, "-" * 30))
-            logging.info("\nmodel is converting, please wait")
             onnx2tnn.convert(onnx_path, output_dir, version, optimize, half, align, input_file, ref_file, input_names)
         except:
-            logging.info("Conversion to  tnn failed :(")
+            logging.info("Conversion to  tnn failed :(\n")
     
     elif args.sub_command == 'caffe2tnn':
         proto_path = parse_path.parse_path(args.proto_path)
@@ -62,11 +62,9 @@ def main():
         input_file = parse_path.parse_path(input_file)
         ref_file = parse_path.parse_path(ref_file)
         try:
-            logging.info("{}  convert model  {}" .format("-" * 30, "-" * 30))
-            logging.info("\nmodel is converting, please wait")
             caffe2tnn.convert(proto_path, model_path, output_dir, version, optimize, half, align, input_file, ref_file)
         except:
-            logging.info("Conversion to  tnn failed :(")
+            logging.info("Conversion to  tnn failed :(\n")
 
     elif args.sub_command == 'tf2tnn':
         tf_path = parse_path.parse_path(args.tf_path)
@@ -84,12 +82,10 @@ def main():
         ref_file = parse_path.parse_path(ref_file)
 
         try:
-            logging.info("{}  convert model  {}" .format("-" * 30, "-" * 30))
-            logging.info("\nmodel is converting, please wait")
-            tf2tnn.convert(tf_path, input_names, output_names, output_dir, version, optimize, half, align, not_fold_const, 
+            tf2tnn.convert(tf_path, input_names, output_names, output_dir, version, optimize, half, align, not_fold_const,
                         input_file, ref_file)
         except:
-            logging.info("\nConversion to  tnn failed :(")
+            logging.info("\nConversion to  tnn failed :(\n")
     elif args.sub_command is None:
         parser.print_help()
     else:

--- a/tools/convert2tnn/onnx_converter/align_model.py
+++ b/tools/convert2tnn/onnx_converter/align_model.py
@@ -39,9 +39,9 @@ def run_tnn_model_check(proto_path, model_path, input_path, reference_output_pat
     ret = cmd.run(command)
 
     if ret == 0:
-        logging.info("model align success!\n")
+        print_align_message()
     else:
-        logging.info("model align failed :(\n")
+        print_not_align_message()
 
     return
 
@@ -84,6 +84,7 @@ def run_onnx(model_path: str, input_path: str, input_info: dict) -> str:
 
 
 def get_input_shape_from_onnx(onnx_path) -> dict:
+    onnxruntime.set_default_logger_severity(3)
     session = onnxruntime.InferenceSession(onnx_path)
     input_info: dict = {}
     for ip in session.get_inputs():
@@ -107,14 +108,14 @@ def get_input_shape_from_tnn(tnn_proto_path):
 
 
 def print_not_align_message(reason):
-    logging.info("==================== Unfortunately============================\n")
+    logging.info("{}   Unfortunately   {}" .format("-" * 10, "-" * 10))
     logging.info("The onnx model not aligned with tnn model\n")
-    logging.info("the reason " + reason)
+    logging.info("the reason " + reason + "\n")
     exit(-1)
 
 
 def print_align_message():
-    logging.info("====================Congratulations!==========================\n")
+    logging.info("{}  Congratulations!   {}" .format("-" * 10, "-" * 10))
     logging.info("the onnx model aligned whit tnn model\n")
 
 
@@ -128,10 +129,10 @@ def check_input_info(onnx_input_info: dict, tnn_input_info: dict):
             onnx_shape[0] = 1
         if tnn_shape != onnx_shape:
             print_not_align_message(
-                "\nthe {}'s shape not equal! the onnx shape:{}, tnn shape: {}".format(name, str(onnx_shape),
+                "the {}'s shape not equal! the onnx shape:{}, tnn shape: {}\n".format(name, str(onnx_shape),
                                                                                     str(tnn_shape)))
     
-    logging.info("\ncheck onnx input shape and tnn input shape align!\n")
+    logging.info("check onnx input shape and tnn input shape align!\n")
 
 def parse_input_names(input_names: str) -> dict:
     input_info = {}
@@ -158,7 +159,7 @@ def align_model(onnx_path: str, tnn_proto_path: str, tnn_model_path: str, input_
     :param tnn_model_path:
     :return:
     """
-    logging.info("{}  align model  {}" .format("-" * 30, "-" * 30))
+    logging.info("{}  align model (ONNX vs TNN),please wait a moment {}\n" .format("-" * 10, "-" * 10))
 
     checker.check_file_exist(tnn_proto_path)
     checker.check_file_exist(tnn_model_path)

--- a/tools/convert2tnn/onnx_converter/onnx2tnn.py
+++ b/tools/convert2tnn/onnx_converter/onnx2tnn.py
@@ -44,6 +44,7 @@ def convert(onnx_path, output_dir=None, version="v1.0", optimize=True, half=Fals
     :return return_code
     :exception 执行超时
     """
+    logging.info("converter ONNX to TNN Model\n")
     ret, current_shape = checker.check_onnx_dim(onnx_path)
 
     if ret is False and current_shape is not None:
@@ -70,7 +71,7 @@ def convert(onnx_path, output_dir=None, version="v1.0", optimize=True, half=Fals
         output_dir = os.path.dirname(onnx_path)
     checker.check_file_exist(output_dir)
     command = command + " -o " + output_dir
-    logging.debug("the onnx2tnn command:" + command)
+    logging.debug("the onnx2tnn command:" + command + "\n")
 
     if input_names is not None:
         new_input_names = ""
@@ -86,9 +87,9 @@ def convert(onnx_path, output_dir=None, version="v1.0", optimize=True, half=Fals
     result = cmd.run(command, work_dir=work_dir)
 
     if result == 0:
-        logging.info("\nonnx2tnn succeed!\n")
+        logging.info("converter ONNX to TNN model succeed!\n")
     else:
-        logging.info("\nonnx2tnn failed!\n")
+        logging.info("converter ONNX to TNN model failed!\n")
         exit(-1)
     onnx_base_name = os.path.basename(onnx_path)
 

--- a/tools/convert2tnn/tf_converter/tf2tnn.py
+++ b/tools/convert2tnn/tf_converter/tf2tnn.py
@@ -78,6 +78,7 @@ def tf2onnx(tf_path, input_names, output_name, onnx_path, not_fold_const=False):
 
 def convert(tf_path, input_names, output_names, output_dir, version, optimize, half, align=False, not_fold_const=False,
             input_path=None, refer_path=None):
+    logging.info("converter Tensorflow to TNN model\n")
     checker.check_file_exist(tf_path)
     model_name = os.path.basename(tf_path)
     if output_dir is None or not os.path.isdir(output_dir):
@@ -86,9 +87,9 @@ def convert(tf_path, input_names, output_names, output_dir, version, optimize, h
     model_name = model_name[:-len(".pb")]
     onnx_path = os.path.join(output_dir, model_name + ".onnx")
     if tf2onnx(tf_path, input_names, output_names, onnx_path, not_fold_const) is False:
-        logging.info("\nOh No, tf2onnx failed")
+        logging.info("Oh No, tf2onnx failed\n")
     else:
-        logging.info("\ncongratulations! tf2onnx succeed!")
+        logging.info("convert TensorFlow to ONNX model succeed!\n")
     if version is None:
         version = "v1.0"
     checker.check_file_exist(onnx_path)

--- a/tools/convert2tnn/utils/checker.py
+++ b/tools/convert2tnn/utils/checker.py
@@ -22,7 +22,7 @@ from converter import logging
 
 def check_file_exist(file_path):
     if os.path.exists(file_path) is False:
-        logging.info("the " + file_path + " does not exist! please make sure the file exist!")
+        logging.info("the " + file_path + " does not exist! please make sure the file exist!\n")
         exit(-1)
 
 
@@ -38,6 +38,7 @@ def is_ssd_model(proto_path):
         return False
 
 def check_onnx_dim(onnx_path : str):
+    onnxruntime.set_default_logger_severity(3)
     session = onnxruntime.InferenceSession(onnx_path)
     current_shape = []
     status = 0

--- a/tools/convert2tnn/utils/cmd.py
+++ b/tools/convert2tnn/utils/cmd.py
@@ -48,8 +48,7 @@ def run(cmd_string, work_dir=None, timeout=None, is_shell=True):
                            cwd=work_dir,
                            close_fds=True)
     (stdout, stderr) = sub.communicate()
-    #logging.debug(str(stdout.decode('utf-8')))
-    #print(str(stdout.decode('utf-8')))
+    logging.debug(str(stdout.decode('utf-8')))
     rc = sub.poll()
     if rc != 0:
         logging.error(str(stderr.decode('utf-8')))

--- a/tools/convert2tnn/utils/cmd.py
+++ b/tools/convert2tnn/utils/cmd.py
@@ -48,7 +48,8 @@ def run(cmd_string, work_dir=None, timeout=None, is_shell=True):
                            cwd=work_dir,
                            close_fds=True)
     (stdout, stderr) = sub.communicate()
-    logging.debug(str(stdout.decode('utf-8')))
+    #logging.debug(str(stdout.decode('utf-8')))
+    #print(str(stdout.decode('utf-8')))
     rc = sub.poll()
     if rc != 0:
         logging.error(str(stderr.decode('utf-8')))


### PR DESCRIPTION
1.  处理了onnx2tnn的日志系统，统一成和TNN一致的日志系统。
2. 统一了Convert2tnn中的日志系统，使用loggging替换前面的print输出，并提供了debug、info、warning以及error四级日志输出，默认输出info、warning和error信息。
目前convert2tnn的日志打印如下：
![企业微信截图_0a66d950-1abb-4d68-bfec-129f26b1a597](https://user-images.githubusercontent.com/5379313/86118199-eedcd500-bb02-11ea-9ee3-b4bdb01d0435.png)
