### PR TITLE
fix bugs in ssd model

### DIFF
--- a/source/tnn/interpreter/tnn/layer_interpreter/detection_output_interpreter.cc
+++ b/source/tnn/interpreter/tnn/layer_interpreter/detection_output_interpreter.cc
@@ -33,7 +33,7 @@ Status DetectionOutputLayerInterpreter::InterpretProto(str_arr layer_cfg_arr, in
 
     int variance_encoded_in_target = 0;
     GET_INT_1(variance_encoded_in_target);
-    p->variance_encoded_in_target = variance_encoded_in_target ? false : true;
+    p->variance_encoded_in_target = variance_encoded_in_target ? true : false;
 
     GET_INT_2(p->code_type, p->keep_top_k);
     GET_FLOAT_2(p->confidence_threshold, p->nms_param.nms_threshold);

--- a/source/tnn/utils/naive_compute.cc
+++ b/source/tnn/utils/naive_compute.cc
@@ -418,7 +418,7 @@ inline CodeType GetCodeType(const int number) {
 
     switch (number) {
         case 1: {
-            return PriorBoxParameter_CodeType_CORNER_SIZE;
+            return PriorBoxParameter_CodeType_CORNER;
         }
         case 2: {
             return PriorBoxParameter_CodeType_CENTER_SIZE;


### PR DESCRIPTION
(1) when interprating detection_output layer in ssd models, variance_encoded_in_target is parsed wrongly;
(2) when codetype=1, the GetCodeType function returns wrong result;