### PR TITLE
fix wrong stepsize in RGBA reverse kernel

### DIFF
--- a/source/tnn/device/arm/arm_blob_converter.cc
+++ b/source/tnn/device/arm/arm_blob_converter.cc
@@ -367,7 +367,7 @@ void RGBAChannelReverse(uint8_t *ptr, int channel, int hw) {
     }
 #endif
     for (; i < hw; i++) {
-        std::swap(ptr[i * channel], ptr[i * channel + 2]);
+        std::swap(ptr[i * 4], ptr[i * 4 + 2]);
     }
 }
 

--- a/source/tnn/device/arm/arm_blob_converter.cc
+++ b/source/tnn/device/arm/arm_blob_converter.cc
@@ -348,7 +348,7 @@ void RGBChannelReverse(uint8_t *ptr, int channel, int hw) {
     }
 #endif
     for (; i < hw; i++) {
-        std::swap(ptr[i * channel], ptr[i * channel + 2]);
+        std::swap(ptr[i * 3], ptr[i * 3 + 2]);
     }
 }
 


### PR DESCRIPTION
fix the wrong stepsize in arm cpu RGBA reverse kernel.
For the rgba data, the stepsize for consecutive channels should be 4 instead of 3