### PR TITLE
[METAL] update KernelName, add inputs and outputs as arguments

### DIFF
--- a/source/tnn/device/metal/acc/convolution/metal_conv_layer_1x1.h
+++ b/source/tnn/device/metal/acc/convolution/metal_conv_layer_1x1.h
@@ -32,7 +32,7 @@ public:
     Status AllocateBufferParam(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
     
 public:
-    virtual std::string KernelName();
+    virtual std::string KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
     virtual Status ComputeThreadSize(const std::vector<Blob *> &inputs,
                                      const std::vector<Blob *> &outputs,
                                      MTLSize &size);

--- a/source/tnn/device/metal/acc/convolution/metal_conv_layer_1x1.mm
+++ b/source/tnn/device/metal/acc/convolution/metal_conv_layer_1x1.mm
@@ -66,7 +66,7 @@ Status MetalConvLayer1x1::AllocateBufferParam(const std::vector<Blob *> &inputs,
     return TNN_OK;
 }
 
-std::string MetalConvLayer1x1::KernelName() {
+std::string MetalConvLayer1x1::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "convolution_1x1";
 }
 

--- a/source/tnn/device/metal/acc/convolution/metal_conv_layer_common.h
+++ b/source/tnn/device/metal/acc/convolution/metal_conv_layer_common.h
@@ -53,7 +53,7 @@ public:
 
     virtual Status AllocateBufferParam(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
 public:
-    virtual std::string KernelName();
+    virtual std::string KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
     virtual Status ComputeThreadSize(const std::vector<Blob *> &inputs,
                                      const std::vector<Blob *> &outputs,
                                      MTLSize &size);

--- a/source/tnn/device/metal/acc/convolution/metal_conv_layer_common.mm
+++ b/source/tnn/device/metal/acc/convolution/metal_conv_layer_common.mm
@@ -111,7 +111,7 @@ Status MetalConvLayerCommon::Reshape(const std::vector<Blob *> &inputs, const st
     return TNN_OK;
 }
 
-std::string MetalConvLayerCommon::KernelName() {
+std::string MetalConvLayerCommon::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "convolution_common";
 }
 
@@ -164,7 +164,7 @@ Status MetalConvLayerCommon::Forward(const std::vector<Blob *> &inputs, const st
         status = ComputeThreadSize(inputs, outputs, threads);
         BREAK_IF(status != TNN_OK);
         
-        auto kernel_name = KernelName();
+        auto kernel_name = KernelName(inputs, outputs);
         if (kernel_name.length() <= 0) {
             status = Status(TNNERR_LAYER_ERR, "empty kernel name");
             break;

--- a/source/tnn/device/metal/acc/convolution/metal_conv_layer_depthwise.h
+++ b/source/tnn/device/metal/acc/convolution/metal_conv_layer_depthwise.h
@@ -34,7 +34,7 @@ public:
     Status AllocateBufferParam(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
     
 public:
-    virtual std::string KernelName();
+    virtual std::string KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
     virtual Status SetKernelEncoderParam(
                                          id<MTLComputeCommandEncoder> encoder,
                                          const std::vector<Blob *> &inputs,

--- a/source/tnn/device/metal/acc/convolution/metal_conv_layer_depthwise.mm
+++ b/source/tnn/device/metal/acc/convolution/metal_conv_layer_depthwise.mm
@@ -75,7 +75,7 @@ Status MetalConvLayerDepthwise::AllocateBufferParam(const std::vector<Blob *> &i
     return TNN_OK;
 }
 
-std::string MetalConvLayerDepthwise::KernelName() {
+std::string MetalConvLayerDepthwise::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "convolution_depthwise";
 }
 

--- a/source/tnn/device/metal/acc/convolution/metal_inner_product_layer_acc.h
+++ b/source/tnn/device/metal/acc/convolution/metal_inner_product_layer_acc.h
@@ -38,7 +38,7 @@ public:
     Status AllocateBufferParam(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
     
 public:
-    virtual std::string KernelName();
+    virtual std::string KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
     virtual Status ComputeThreadSize(const std::vector<Blob *> &inputs,
                                      const std::vector<Blob *> &outputs,
                                      MTLSize &size);

--- a/source/tnn/device/metal/acc/convolution/metal_inner_product_layer_acc.mm
+++ b/source/tnn/device/metal/acc/convolution/metal_inner_product_layer_acc.mm
@@ -139,7 +139,7 @@ Status MetalInnerProductLayerAcc::Reshape(const std::vector<Blob *> &inputs,
     return MetalConvLayerCommon::Reshape(inputs, outputs);
 }
 
-std::string MetalInnerProductLayerAcc::KernelName() {
+std::string MetalInnerProductLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "inner_product";
 }
 

--- a/source/tnn/device/metal/acc/deconvolution/metal_deconv_layer_depthwise.h
+++ b/source/tnn/device/metal/acc/deconvolution/metal_deconv_layer_depthwise.h
@@ -32,7 +32,7 @@ public:
     Status AllocateBufferWeight(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
     
 public:
-    virtual std::string KernelName();
+    virtual std::string KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
     virtual Status ComputeThreadSize(const std::vector<Blob *> &inputs,
                                      const std::vector<Blob *> &outputs,
                                      MTLSize &size);

--- a/source/tnn/device/metal/acc/deconvolution/metal_deconv_layer_depthwise.mm
+++ b/source/tnn/device/metal/acc/deconvolution/metal_deconv_layer_depthwise.mm
@@ -48,7 +48,7 @@ Status MetalDeconvLayerDepthwise::AllocateBufferWeight(
     return status;
 }
 
-std::string MetalDeconvLayerDepthwise::KernelName() {
+std::string MetalDeconvLayerDepthwise::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "deconv_depthwise";
 }
 

--- a/source/tnn/device/metal/acc/metal_abs_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_abs_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Abs, LAYER_ABS);
 
-string MetalAbsLayerAcc::KernelName() {
+string MetalAbsLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "abs";
 }
 

--- a/source/tnn/device/metal/acc/metal_acos_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_acos_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Acos, LAYER_ACOS);
 
-string MetalAcosLayerAcc::KernelName() {
+string MetalAcosLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "acos";
 }
 

--- a/source/tnn/device/metal/acc/metal_add_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_add_layer_acc.mm
@@ -18,7 +18,7 @@
 namespace TNN_NS {
 DECLARE_METAL_MULTIDIR_BROADCAST_ACC(Add, LAYER_ADD);
 
-std::string MetalAddLayerAcc::KernelName() {
+std::string MetalAddLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     std::string kernel_name = "";
     auto layer_param        = dynamic_cast<MultidirBroadcastLayerParam *>(param_);
     if (!layer_param) {

--- a/source/tnn/device/metal/acc/metal_asin_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_asin_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Asin, LAYER_ASIN);
 
-string MetalAsinLayerAcc::KernelName() {
+string MetalAsinLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "asin";
 }
 

--- a/source/tnn/device/metal/acc/metal_atan_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_atan_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Atan, LAYER_ATAN);
 
-string MetalAtanLayerAcc::KernelName() {
+string MetalAtanLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "atan";
 }
 

--- a/source/tnn/device/metal/acc/metal_ceil_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_ceil_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Ceil, LAYER_CEIL);
 
-string MetalCeilLayerAcc::KernelName() {
+string MetalCeilLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "ceil";
 }
 

--- a/source/tnn/device/metal/acc/metal_clip_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_clip_layer_acc.mm
@@ -19,7 +19,7 @@
 namespace TNN_NS {
 DECLARE_METAL_UNARY_ACC(Clip, LAYER_CLIP);
 
-string MetalClipLayerAcc::KernelName() {
+string MetalClipLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "clip";
 }
 

--- a/source/tnn/device/metal/acc/metal_cos_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_cos_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Cos, LAYER_COS);
 
-string MetalCosLayerAcc::KernelName() {
+string MetalCosLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "cos";
 }
 

--- a/source/tnn/device/metal/acc/metal_div_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_div_layer_acc.mm
@@ -18,7 +18,7 @@
 namespace TNN_NS {
 DECLARE_METAL_MULTIDIR_BROADCAST_ACC(Div, LAYER_DIV);
 
-std::string MetalDivLayerAcc::KernelName() {
+std::string MetalDivLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     std::string kernel_name = "";
     auto layer_param        = dynamic_cast<MultidirBroadcastLayerParam *>(param_);
     if (!layer_param) {

--- a/source/tnn/device/metal/acc/metal_elu_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_elu_layer_acc.mm
@@ -19,7 +19,7 @@
 namespace TNN_NS {
 DECLARE_METAL_UNARY_ACC(Elu, LAYER_ELU);
 
-string MetalEluLayerAcc::KernelName() {
+string MetalEluLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "elu";
 }
 

--- a/source/tnn/device/metal/acc/metal_exp_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_exp_layer_acc.mm
@@ -19,7 +19,7 @@
 namespace TNN_NS {
 DECLARE_METAL_UNARY_ACC(Exp, LAYER_EXP);
 
-string MetalExpLayerAcc::KernelName() {
+string MetalExpLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "exp";
 }
 

--- a/source/tnn/device/metal/acc/metal_floor_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_floor_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Floor, LAYER_FLOOR);
 
-string MetalFloorLayerAcc::KernelName() {
+string MetalFloorLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "floor";
 }
 

--- a/source/tnn/device/metal/acc/metal_hard_sigmoid_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_hard_sigmoid_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(HardSigmoid, LAYER_HARDSIGMOID);
 
-string MetalHardSigmoidLayerAcc::KernelName() {
+string MetalHardSigmoidLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "hard_sigmoid";
 }
 

--- a/source/tnn/device/metal/acc/metal_hard_swish_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_hard_swish_layer_acc.mm
@@ -55,7 +55,7 @@ Status MetalHardSwishLayerAcc::AllocateBufferParam(const std::vector<Blob *> &in
     return TNN_OK;
 }
 
-std::string MetalHardSwishLayerAcc::KernelName() {
+std::string MetalHardSwishLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "hard_swish";
 }
 

--- a/source/tnn/device/metal/acc/metal_layer_acc.h
+++ b/source/tnn/device/metal/acc/metal_layer_acc.h
@@ -43,7 +43,8 @@ public:
     
 
 public:
-    virtual std::string KernelName();
+    virtual std::string KernelName(const std::vector<Blob *> &inputs,
+                                   const std::vector<Blob *> &outputs);
     
     virtual Status ComputeThreadSize(const std::vector<Blob *> &inputs,
                                      const std::vector<Blob *> &outputs,
@@ -102,7 +103,7 @@ id<MTLBuffer> AllocatePackedNC4HW4MetalBufferFormRawBuffer(RawBuffer buffer, Dim
         virtual Status Reshape(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);                 \
         virtual Status AllocateBufferParam(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);     \
         virtual Status Forward(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);                 \
-        virtual std::string KernelName(); \
+        virtual std::string KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs); \
         virtual Status ComputeThreadSize(const std::vector<Blob *> &inputs, \
                                  const std::vector<Blob *> &outputs, \
                                  MTLSize &size); \

--- a/source/tnn/device/metal/acc/metal_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_layer_acc.mm
@@ -65,7 +65,8 @@ Status MetalLayerAcc::AllocateBufferParam(const std::vector<Blob *> &inputs, con
     return TNN_OK;
 }
 
-std::string MetalLayerAcc::KernelName() {
+std::string MetalLayerAcc::KernelName(const std::vector<Blob *> &inputs,
+                                      const std::vector<Blob *> &outputs) {
     LOGE("Error: subclass must implement the interface KernelName\n");
     return "";
 }
@@ -119,7 +120,7 @@ Status MetalLayerAcc::Forward(const std::vector<Blob *> &inputs, const std::vect
     }
     
     do {
-        auto kernel_name = KernelName();
+        auto kernel_name = KernelName(inputs, outputs);
         if (kernel_name.length() <= 0) {
             status = Status(TNNERR_LAYER_ERR, "empty kernel name");
             break;

--- a/source/tnn/device/metal/acc/metal_log_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_log_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Log, LAYER_LOG);
 
-string MetalLogLayerAcc::KernelName() {
+string MetalLogLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "log";
 }
 

--- a/source/tnn/device/metal/acc/metal_log_sigmoid_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_log_sigmoid_layer_acc.mm
@@ -19,7 +19,7 @@
 namespace TNN_NS {
 DECLARE_METAL_UNARY_ACC(LogSigmoid, LAYER_LOGSIGMOID);
 
-string MetalLogSigmoidLayerAcc::KernelName() {
+string MetalLogSigmoidLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "log_sigmoid";
 }
 

--- a/source/tnn/device/metal/acc/metal_lrn_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_lrn_layer_acc.mm
@@ -41,7 +41,7 @@ Status MetalLRNLayerAcc::AllocateBufferParam(const std::vector<Blob *> &inputs, 
     return TNN_OK;
 }
 
-std::string MetalLRNLayerAcc::KernelName() {
+std::string MetalLRNLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "lrn_across_channel";
 }
 

--- a/source/tnn/device/metal/acc/metal_max_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_max_layer_acc.mm
@@ -19,7 +19,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_MULTIDIR_BROADCAST_ACC(Max, LAYER_MAXIMUM);
 
-std::string MetalMaxLayerAcc::KernelName() {
+std::string MetalMaxLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     std::string kernel_name = "";
     auto layer_param        = dynamic_cast<MultidirBroadcastLayerParam *>(param_);
     if (!layer_param) {

--- a/source/tnn/device/metal/acc/metal_min_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_min_layer_acc.mm
@@ -19,7 +19,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_MULTIDIR_BROADCAST_ACC(Min, LAYER_MINIMUM);
 
-std::string MetalMinLayerAcc::KernelName() {
+std::string MetalMinLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     std::string kernel_name = "";
     auto layer_param        = dynamic_cast<MultidirBroadcastLayerParam *>(param_);
     if (!layer_param) {

--- a/source/tnn/device/metal/acc/metal_mul_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_mul_layer_acc.mm
@@ -19,7 +19,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_MULTIDIR_BROADCAST_ACC(Mul, LAYER_MUL);
 
-std::string MetalMulLayerAcc::KernelName() {
+std::string MetalMulLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     std::string kernel_name = "";
     auto layer_param        = dynamic_cast<MultidirBroadcastLayerParam *>(param_);
     if (!layer_param) {

--- a/source/tnn/device/metal/acc/metal_multidir_broadcast_layer_acc.h
+++ b/source/tnn/device/metal/acc/metal_multidir_broadcast_layer_acc.h
@@ -30,7 +30,7 @@ public:
     virtual Status Forward(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
     
 public:
-    virtual std::string KernelName();
+    virtual std::string KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
     virtual Status ComputeThreadSize(const std::vector<Blob *> &inputs,
                                      const std::vector<Blob *> &outputs,
                                      MTLSize &size);
@@ -47,7 +47,7 @@ protected:
     class Metal##type_string##LayerAcc : public MetalMultidirBroadcastLayerAcc {                                       \
     public:                                                                                                            \
         virtual ~Metal##type_string##LayerAcc(){};                                                                     \
-        virtual std::string KernelName();                                                                              \
+        virtual std::string KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);         \
         virtual Status Reshape(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);                 \
         virtual Status Forward(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);                 \
     }

--- a/source/tnn/device/metal/acc/metal_multidir_broadcast_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_multidir_broadcast_layer_acc.mm
@@ -67,7 +67,7 @@ Status MetalMultidirBroadcastLayerAcc::AllocateBufferParam(const std::vector<Blo
     return status;
 }
 
-std::string MetalMultidirBroadcastLayerAcc::KernelName() {
+std::string MetalMultidirBroadcastLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "";
 }
 

--- a/source/tnn/device/metal/acc/metal_neg_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_neg_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Neg, LAYER_NEG);
 
-string MetalNegLayerAcc::KernelName() {
+string MetalNegLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "neg";
 }
 

--- a/source/tnn/device/metal/acc/metal_normalize_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_normalize_layer_acc.mm
@@ -51,7 +51,7 @@ Status MetalNormalizeLayerAcc::AllocateBufferParam(const std::vector<Blob *> &in
     return TNN_OK;
 }
 
-std::string MetalNormalizeLayerAcc::KernelName() {
+std::string MetalNormalizeLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "";
 }
 

--- a/source/tnn/device/metal/acc/metal_pad_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_pad_layer_acc.mm
@@ -57,7 +57,7 @@ Status MetalPadLayerAcc::ComputeThreadSize(const std::vector<Blob *> &inputs,
     return TNN_OK;
 }
 
-std::string MetalPadLayerAcc::KernelName() {
+std::string MetalPadLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     auto layer_param = dynamic_cast<PadLayerParam *>(param_);
     if (!layer_param) {
         LOGE("Error: layer param is nil\n");

--- a/source/tnn/device/metal/acc/metal_permute_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_permute_layer_acc.mm
@@ -37,7 +37,7 @@ Status MetalPermuteLayerAcc::SetKernelEncoderParam(
     return MetalLayerAcc::SetKernelEncoderParam(encoder, inputs, outputs);
 }
 
-std::string MetalPermuteLayerAcc::KernelName() {
+std::string MetalPermuteLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     auto layer_param = dynamic_cast<PermuteLayerParam *>(param_);
     if (layer_param->orders[0] == 0 && layer_param->orders[1] == 2 &&
         layer_param->orders[2] == 3 && layer_param->orders[3] == 1) {

--- a/source/tnn/device/metal/acc/metal_pooling_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_pooling_layer_acc.mm
@@ -56,7 +56,7 @@ Status MetalPoolingLayerAcc::AllocateBufferParam(const std::vector<Blob *> &inpu
     return TNN_OK;
 }
 
-std::string MetalPoolingLayerAcc::KernelName() {
+std::string MetalPoolingLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     auto param = dynamic_cast<PoolingLayerParam *>(param_);
     const int pool_type = param->pool_type;
     return pool_type == 0 ? "pooling_max" : "pooling_avg";

--- a/source/tnn/device/metal/acc/metal_pow_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_pow_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Pow, LAYER_POWER);
 
-string MetalPowLayerAcc::KernelName() {
+string MetalPowLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "pow";
 }
 

--- a/source/tnn/device/metal/acc/metal_reciprocal_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reciprocal_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Reciprocal, LAYER_RECIPROCAL);
 
-string MetalReciprocalLayerAcc::KernelName() {
+string MetalReciprocalLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "reciprocal";
 }
 

--- a/source/tnn/device/metal/acc/metal_reduce_l1_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reduce_l1_layer_acc.mm
@@ -18,7 +18,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_REDUCE_ACC(ReduceL1, LAYER_REDUCE_L1);
 
-std::string MetalReduceL1LayerAcc::KernelName() {
+std::string MetalReduceL1LayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     if (axis_ == 0) {
         return "reduce_l1_axis_0_common";
     } else if (axis_ == 1) {

--- a/source/tnn/device/metal/acc/metal_reduce_l2_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reduce_l2_layer_acc.mm
@@ -18,7 +18,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_REDUCE_ACC(ReduceL2, LAYER_REDUCE_L2);
 
-std::string MetalReduceL2LayerAcc::KernelName() {
+std::string MetalReduceL2LayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     if (axis_ == 0) {
         return "reduce_l2_axis_0_common";
     } else if (axis_ == 1) {

--- a/source/tnn/device/metal/acc/metal_reduce_layer_acc.h
+++ b/source/tnn/device/metal/acc/metal_reduce_layer_acc.h
@@ -30,7 +30,7 @@ public:
     /**
      * @brief metal kernel name
      */
-    virtual std::string KernelName();
+    virtual std::string KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
 
     virtual Status Forward(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
 
@@ -43,7 +43,7 @@ protected:
     class Metal##type_string##LayerAcc : public MetalReduceLayerAcc {                                                  \
     public:                                                                                                            \
         virtual ~Metal##type_string##LayerAcc(){};                                                                     \
-        virtual std::string KernelName();                                                                              \
+        virtual std::string KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);         \
         virtual Status Reshape(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);                 \
         virtual Status Forward(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);                 \
     }

--- a/source/tnn/device/metal/acc/metal_reduce_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reduce_layer_acc.mm
@@ -51,7 +51,7 @@ Status MetalReduceLayerAcc::AllocateBufferParam(const std::vector<Blob *> &input
     return TNN_OK;
 }
 
-std::string MetalReduceLayerAcc::KernelName() {
+std::string MetalReduceLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "";
 }
 
@@ -83,7 +83,7 @@ Status MetalReduceLayerAcc::Forward(const std::vector<Blob *> &inputs, const std
     string data_type_str = DataTypeUtils::GetDataTypeString(data_type);
 
     do {
-        auto kernel_name = KernelName();
+        auto kernel_name = KernelName(inputs, outputs);
         if (kernel_name.length() <= 0) {
             LOGE("Error: empty kernel name\n");
             status = Status(TNNERR_LAYER_ERR, "empty kernel name");

--- a/source/tnn/device/metal/acc/metal_reduce_log_sum_exp_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reduce_log_sum_exp_layer_acc.mm
@@ -18,7 +18,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_REDUCE_ACC(ReduceLogSumExp, LAYER_REDUCE_LOG_SUM_EXP);
 
-std::string MetalReduceLogSumExpLayerAcc::KernelName() {
+std::string MetalReduceLogSumExpLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     if (axis_ == 0) {
         return "reduce_log_sum_exp_axis_0_common";
     } else if (axis_ == 1) {

--- a/source/tnn/device/metal/acc/metal_reduce_log_sum_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reduce_log_sum_layer_acc.mm
@@ -18,7 +18,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_REDUCE_ACC(ReduceLogSum, LAYER_REDUCE_LOG_SUM);
 
-std::string MetalReduceLogSumLayerAcc::KernelName() {
+std::string MetalReduceLogSumLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     if (axis_ == 0) {
         return "reduce_log_sum_axis_0_common";
     } else if (axis_ == 1) {

--- a/source/tnn/device/metal/acc/metal_reduce_max_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reduce_max_layer_acc.mm
@@ -18,7 +18,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_REDUCE_ACC(ReduceMax, LAYER_REDUCE_MAX);
 
-std::string MetalReduceMaxLayerAcc::KernelName() {
+std::string MetalReduceMaxLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     if (axis_ == 0) {
         return "reduce_max_axis_0_common";
     } else if (axis_ == 1) {

--- a/source/tnn/device/metal/acc/metal_reduce_mean_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reduce_mean_layer_acc.mm
@@ -18,7 +18,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_REDUCE_ACC(ReduceMean, LAYER_REDUCE_MEAN);
 
-std::string MetalReduceMeanLayerAcc::KernelName() {
+std::string MetalReduceMeanLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     if (axis_ == 0) {
         return "reduce_mean_axis_0_common";
     } else if (axis_ == 1) {

--- a/source/tnn/device/metal/acc/metal_reduce_min_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reduce_min_layer_acc.mm
@@ -18,7 +18,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_REDUCE_ACC(ReduceMin, LAYER_REDUCE_MIN);
 
-std::string MetalReduceMinLayerAcc::KernelName() {
+std::string MetalReduceMinLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     if (axis_ == 0) {
         return "reduce_min_axis_0_common";
     } else if (axis_ == 1) {

--- a/source/tnn/device/metal/acc/metal_reduce_prod_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reduce_prod_layer_acc.mm
@@ -18,7 +18,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_REDUCE_ACC(ReduceProd, LAYER_REDUCE_PROD);
 
-std::string MetalReduceProdLayerAcc::KernelName() {
+std::string MetalReduceProdLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     if (axis_ == 0) {
         return "reduce_prod_axis_0_common";
     } else if (axis_ == 1) {

--- a/source/tnn/device/metal/acc/metal_reduce_sum_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reduce_sum_layer_acc.mm
@@ -18,7 +18,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_REDUCE_ACC(ReduceSum, LAYER_REDUCE_SUM);
 
-std::string MetalReduceSumLayerAcc::KernelName() {
+std::string MetalReduceSumLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     if (axis_ == 0) {
         return "reduce_sum_axis_0_common";
     } else if (axis_ == 1) {

--- a/source/tnn/device/metal/acc/metal_reduce_sum_square_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reduce_sum_square_layer_acc.mm
@@ -18,7 +18,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_REDUCE_ACC(ReduceSumSquare, LAYER_REDUCE_SUM_SQUARE);
 
-std::string MetalReduceSumSquareLayerAcc::KernelName() {
+std::string MetalReduceSumSquareLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     if (axis_ == 0) {
         return "reduce_sum_square_axis_0_common";
     } else if (axis_ == 1) {

--- a/source/tnn/device/metal/acc/metal_relu6_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_relu6_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Relu6, LAYER_RELU6);
 
-string MetalRelu6LayerAcc::KernelName() {
+string MetalRelu6LayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "relu6";
 }
 

--- a/source/tnn/device/metal/acc/metal_relu_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_relu_layer_acc.mm
@@ -19,7 +19,7 @@
 namespace TNN_NS {
 DECLARE_METAL_UNARY_ACC(Relu, LAYER_RELU);
 
-string MetalReluLayerAcc::KernelName() {
+string MetalReluLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "relu";
 }
 

--- a/source/tnn/device/metal/acc/metal_reshape_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_reshape_layer_acc.mm
@@ -30,7 +30,7 @@ Status MetalReshapeLayerAcc::AllocateBufferParam(const std::vector<Blob *> &inpu
     return MetalLayerAcc::AllocateBufferParam(inputs, outputs);;
 }
 
-std::string MetalReshapeLayerAcc::KernelName() {
+std::string MetalReshapeLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "reshape_common";
 }
 

--- a/source/tnn/device/metal/acc/metal_selu_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_selu_layer_acc.mm
@@ -18,7 +18,7 @@
 namespace TNN_NS {
 DECLARE_METAL_UNARY_ACC(Selu, LAYER_SELU);
 
-string MetalSeluLayerAcc::KernelName() {
+string MetalSeluLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "selu";
 }
 

--- a/source/tnn/device/metal/acc/metal_shuffle_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_shuffle_layer_acc.mm
@@ -77,7 +77,7 @@ Status MetalShuffleLayerAcc::AllocateBufferParam(const std::vector<Blob *> &inpu
     return TNN_OK;
 }
 
-std::string MetalShuffleLayerAcc::KernelName() {
+std::string MetalShuffleLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "channel_shuffle";
 }
 

--- a/source/tnn/device/metal/acc/metal_sigmoid_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_sigmoid_layer_acc.mm
@@ -19,7 +19,7 @@
 namespace TNN_NS {
 DECLARE_METAL_UNARY_ACC(Sigmoid, LAYER_SIGMOID);
 
-string MetalSigmoidLayerAcc::KernelName() {
+string MetalSigmoidLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "sigmoid";
 }
 

--- a/source/tnn/device/metal/acc/metal_sign_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_sign_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Sign, LAYER_SIGN);
 
-string MetalSignLayerAcc::KernelName() {
+string MetalSignLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "sign";
 }
 

--- a/source/tnn/device/metal/acc/metal_signed_mul_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_signed_mul_layer_acc.mm
@@ -20,7 +20,7 @@
 namespace TNN_NS {
 DECLARE_METAL_UNARY_ACC(SignedMul, LAYER_SIGNED_MUL);
 
-string MetalSignedMulLayerAcc::KernelName() {
+string MetalSignedMulLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "signed_mul";
 }
 

--- a/source/tnn/device/metal/acc/metal_sin_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_sin_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Sin, LAYER_SIN);
 
-string MetalSinLayerAcc::KernelName() {
+string MetalSinLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "sin";
 }
 

--- a/source/tnn/device/metal/acc/metal_softmax_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_softmax_layer_acc.mm
@@ -49,7 +49,7 @@ Status MetalSoftmaxLayerAcc::AllocateBufferParam(const std::vector<Blob *> &inpu
     return TNN_OK;
 }
 
-std::string MetalSoftmaxLayerAcc::KernelName() {
+std::string MetalSoftmaxLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "";
 }
 

--- a/source/tnn/device/metal/acc/metal_softplus_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_softplus_layer_acc.mm
@@ -19,7 +19,7 @@
 namespace TNN_NS {
 DECLARE_METAL_UNARY_ACC(Softplus, LAYER_SOFTPLUS);
 
-string MetalSoftplusLayerAcc::KernelName() {
+string MetalSoftplusLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "softplus";
 }
 

--- a/source/tnn/device/metal/acc/metal_splitv_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_splitv_layer_acc.mm
@@ -29,7 +29,7 @@ Status MetalSplitVLayerAcc::AllocateBufferParam(const std::vector<Blob *> &input
     return  MetalLayerAcc::AllocateBufferParam(inputs, outputs);
 }
 
-std::string MetalSplitVLayerAcc::KernelName() {
+std::string MetalSplitVLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "";
 }
 

--- a/source/tnn/device/metal/acc/metal_sqrt_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_sqrt_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Sqrt, LAYER_SQRT);
 
-string MetalSqrtLayerAcc::KernelName() {
+string MetalSqrtLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "sqrt";
 }
 

--- a/source/tnn/device/metal/acc/metal_stride_slice_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_stride_slice_layer_acc.mm
@@ -84,7 +84,7 @@ Status MetalStrideSliceLayerAcc::AllocateBufferParam(const std::vector<Blob *> &
     return TNN_OK;
 }
 
-std::string MetalStrideSliceLayerAcc::KernelName() {
+std::string MetalStrideSliceLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "stride_slice_common";
 }
 

--- a/source/tnn/device/metal/acc/metal_sub_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_sub_layer_acc.mm
@@ -18,7 +18,7 @@
 namespace TNN_NS {
 DECLARE_METAL_MULTIDIR_BROADCAST_ACC(Sub, LAYER_SUB);
 
-std::string MetalSubLayerAcc::KernelName() {
+std::string MetalSubLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     std::string kernel_name = "";
     auto layer_param        = dynamic_cast<MultidirBroadcastLayerParam *>(param_);
     if (!layer_param) {

--- a/source/tnn/device/metal/acc/metal_tan_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_tan_layer_acc.mm
@@ -20,7 +20,7 @@ namespace TNN_NS {
 
 DECLARE_METAL_UNARY_ACC(Tan, LAYER_TAN);
 
-string MetalTanLayerAcc::KernelName() {
+string MetalTanLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "tan";
 }
 

--- a/source/tnn/device/metal/acc/metal_tanh_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_tanh_layer_acc.mm
@@ -19,7 +19,7 @@
 namespace TNN_NS {
 DECLARE_METAL_UNARY_ACC(Tanh, LAYER_TANH);
 
-string MetalTanhLayerAcc::KernelName() {
+string MetalTanhLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "tanh";
 }
 

--- a/source/tnn/device/metal/acc/metal_unary_layer_acc.h
+++ b/source/tnn/device/metal/acc/metal_unary_layer_acc.h
@@ -28,7 +28,7 @@ public:
     /**
      * @brief metal kernel name
      */
-    virtual std::string KernelName();
+    virtual std::string KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
 
     Status AllocateBufferParam(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);
 
@@ -47,7 +47,7 @@ public:
     class Metal##type_string##LayerAcc : public MetalUnaryLayerAcc {                                                   \
     public:                                                                                                            \
         virtual ~Metal##type_string##LayerAcc(){};                                                                     \
-        std::string KernelName();                                                                                      \
+        std::string KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);                 \
         Status AllocateBufferParam(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);             \
         Status Forward(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs);                         \
     }

--- a/source/tnn/device/metal/acc/metal_unary_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_unary_layer_acc.mm
@@ -28,7 +28,7 @@ Status MetalUnaryLayerAcc::AllocateBufferParam(const std::vector<Blob *> &inputs
     return  MetalLayerAcc::AllocateBufferParam(inputs, outputs);
 }
 
-std::string MetalUnaryLayerAcc::KernelName() {
+std::string MetalUnaryLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     return "";
 }
 

--- a/source/tnn/device/metal/acc/metal_upsample_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_upsample_layer_acc.mm
@@ -79,7 +79,7 @@ Status MetalUpsampleLayerAcc::ComputeThreadSize(const std::vector<Blob *> &input
     return TNN_OK;
 }
 
-std::string MetalUpsampleLayerAcc::KernelName() {
+std::string MetalUpsampleLayerAcc::KernelName(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) {
     auto layer_param = dynamic_cast<UpsampleLayerParam *>(param_);
     if (layer_param->type == 1) {
         // nearest align_corners=False?待确认


### PR DESCRIPTION
Add inputs and outputs to the argument of KernelName(). MetalAcc could decide specific metal kernel names with the information of input and output blobs.