### PR TITLE
use sin and cos to fix tan calc error on some devices(such as LON-AL00)

### DIFF
--- a/source/tnn/device/opencl/acc/opencl_tan_layer_acc.cc
+++ b/source/tnn/device/opencl/acc/opencl_tan_layer_acc.cc
@@ -31,7 +31,8 @@ Status OpenCLTanLayerAcc::Init(Context *context, LayerParam *param, LayerResourc
 
 std::set<std::string> OpenCLTanLayerAcc::CreateBuildOptions() {
     std::set<std::string> build_options;
-    std::string compute = "tan(in)";
+    // 使用sin和cos计算Tan，而不是tan计算的原因是OpenCL tan在部分机型上（如LON-AL00）会出现错误
+    std::string compute = "sin(in)/cos(in)";
     build_options.emplace(" -DOPERATOR=" + compute);
     return build_options;
 }


### PR DESCRIPTION
修复部分机型上OpenCL tan层计算错误的问题，android ut测试Pass