### PR TITLE
[BUG] fix leayer leak bug when layer init failed

### DIFF
--- a/source/tnn/core/default_network.cc
+++ b/source/tnn/core/default_network.cc
@@ -193,6 +193,8 @@ Status DefaultNetwork::InitLayers(NetStructure *net_structure, NetResource *net_
         ret = cur_layer->Init(context_, layer_info->param.get(), layer_resource, inputs, outputs, device_);
         if (ret != TNN_OK) {
             LOGE("Error Init layer %s (err: %d or 0x%X)\n", cur_layer->GetLayerName().c_str(), (int)ret, (int)ret);
+            // release layer if Init failed
+            delete cur_layer;
             return ret;
         }
 


### PR DESCRIPTION
当layer init失败时，释放已经建立的layer