### PR TITLE
[Metal][UPD] update metal permute

### DIFF
--- a/source/tnn/device/metal/acc/metal_permute_layer_acc.metal
+++ b/source/tnn/device/metal/acc/metal_permute_layer_acc.metal
@@ -42,10 +42,9 @@ kernel void permute_to_nhwc(const device ftype4 *src                  [[buffer(0
     int input_width = index_height;
     
     int4 input_i = index_width % 4;
-    int4 index_in = input_batch * params.input_slice * params.input_size +
-    input_slice * params.input_size +
-    input_height * params.input_width
-    + input_width;
+    int4 index_in = input_batch * params.input_slice * params.input_size + \
+                    input_slice * params.input_size + \
+                    input_height * params.input_width + input_width;
     
     ftype4 val = ftype4(
         src[index_in[0]][input_i[0]],
@@ -81,10 +80,9 @@ kernel void permute_to_nhcw(const device ftype4 *src                  [[buffer(0
     int input_width = index_width;
     
     int4 input_i = index_height % 4;
-    int4 index_in = input_batch * params.input_slice * params.input_size +
-    input_slice * params.input_size +
-    input_height * params.input_width
-    + input_width;
+    int4 index_in = input_batch * params.input_slice * params.input_size + \
+                    input_slice * params.input_size + \
+                    input_height * params.input_width + input_width;
     
     ftype4 val = ftype4(
         src[index_in[0]][input_i[0]],
@@ -120,10 +118,47 @@ kernel void permute_to_nwch(const device ftype4 *src                  [[buffer(0
     input_width = clamp(input_width, 0, params.input_width-1);
 
     int4 input_i = index_height % 4;
-    int4 index_in = input_batch * params.input_slice * params.input_size +
-    input_slice * params.input_size +
-    input_height * params.input_width
-    + input_width;
+    int4 index_in = input_batch * params.input_slice * params.input_size + \
+                    input_slice * params.input_size + \
+                    input_height * params.input_width + input_width;
+
+    ftype4 val = ftype4(
+        src[index_in[0]][input_i[0]],
+        src[index_in[1]][input_i[1]],
+        src[index_in[2]][input_i[2]],
+        src[index_in[3]][input_i[3]]
+    );
+    val = select(ftype4(0), val, valid_position);
+    dst[index_out] = val;
+}
+
+kernel void permute_to_nwhc(const device ftype4 *src                  [[buffer(0)]],
+                                                device ftype4 *dst                            [[buffer(1)]],
+                                                constant MetalParams &params     [[buffer(2)]],
+                                                uint3 gid                                          [[thread_position_in_grid]]) {
+    if (any(gid >= uint3(params.output_width, params.output_height, params.output_slice * params.batch)))
+        return;
+    //0, 3, 2, 1
+    int index_out = (int)gid.z * params.output_size + (int)gid.y * params.output_width + (int)gid.x;
+
+    int index_batch = gid.z / params.output_slice;
+    int output_slice = gid.z % params.output_slice;
+    int4 index_channel = output_slice*4 + int4(0, 1, 2, 3);
+    int index_height = gid.y;
+    int index_width = gid.x;
+    //n w c h
+
+    int input_batch = index_batch;
+    int input_slice = index_width/4;
+    int input_height = index_height;
+    int4 input_width = index_channel;
+    bool4 valid_position = input_width < params.input_width;
+    input_width = clamp(input_width, 0, params.input_width-1);
+
+    int4 input_i = index_width % 4;
+    int4 index_in = input_batch * params.input_slice * params.input_size + \
+                    input_slice * params.input_size + \
+                    input_height * params.input_width + input_width;
 
     ftype4 val = ftype4(
         src[index_in[0]][input_i[0]],
@@ -159,10 +194,9 @@ kernel void permute_to_chwn(const device ftype4 *src                  [[buffer(0
     int input_width = index_height;
 
     int4 input_i = index_batch % 4;
-    int4 index_in = input_batch * params.input_slice * params.input_size +
-    input_slice * params.input_size +
-    input_height * params.input_width
-    + input_width;
+    int4 index_in = input_batch * params.input_slice * params.input_size + \
+                    input_slice * params.input_size + \
+                    input_height * params.input_width + input_width;
 
     ftype4 val = ftype4(
         src[index_in[0]][input_i[0]],

--- a/test/unit_test/layer_test/test_permute_layer.cc
+++ b/test/unit_test/layer_test/test_permute_layer.cc
@@ -22,7 +22,7 @@ namespace TNN_NS {
 class PermuteLayerTest : public LayerTest, public ::testing::WithParamInterface<std::tuple<int, int, int, int>> {};
 
 INSTANTIATE_TEST_SUITE_P(LayerTest, PermuteLayerTest,
-                         ::testing::Combine(BASIC_BATCH_CHANNEL_SIZE, testing::Values(0, 1, 2, 3)));
+                         ::testing::Combine(BASIC_BATCH_CHANNEL_SIZE, testing::Values(0, 1, 2, 3, 4, 5)));
 
 TEST_P(PermuteLayerTest, PermuteLayer) {
     // get param
@@ -46,6 +46,10 @@ TEST_P(PermuteLayerTest, PermuteLayer) {
         param->orders = {0, 3, 1, 2};
     } else if (3 == order_type) {
         param->orders = {1, 2, 3, 0};
+    } else if (4 == order_type) {
+        param->orders = {0, 3, 2, 1};
+    } else if (5 == order_type) {
+        param->orders = {0, 2, 1, 3};
     }
 
     // generate interpreter


### PR DESCRIPTION
1、更新metal permute layer acc，支持nwhc形式；
2、在layer init时检查permute参数，对当前不支持的参数报错；
3、更新unit_test
相关issue: #666 