### PR TITLE
Patch rknpu cache

### DIFF
--- a/include/tnn/core/common.h
+++ b/include/tnn/core/common.h
@@ -115,7 +115,8 @@ typedef enum {
     MODEL_TYPE_COREML   = 0x2000,
     MODEL_TYPE_SNPE     = 0x3000,
     MODEL_TYPE_HIAI     = 0x4000,
-    MODEL_TYPE_ATLAS    = 0x5000
+    MODEL_TYPE_ATLAS    = 0x5000,
+    MODEL_TYPE_RKCACHE  = 0x6000
 } ModelType;
 
 using DimsVector = std::vector<int>;

--- a/source/tnn/device/rknpu/convert/rknpu_reduce_mean_layer.cc
+++ b/source/tnn/device/rknpu/convert/rknpu_reduce_mean_layer.cc
@@ -37,7 +37,7 @@ Status RknpuReduceMeanLayer::Convert() {
     ADD_OUTPUT_OP();
 
     std::vector<int> axes                 = param->axis;
-    std::vector<uint32_t> input_shape_vec = input_ops_[0]->GetDims();
+    std::vector<int32_t> input_shape_vec = input_ops_[0]->GetDims();
 
     // check if all reduce
     if (param->all_reduce) {

--- a/source/tnn/device/rknpu/convert/rknpu_utils.cc
+++ b/source/tnn/device/rknpu/convert/rknpu_utils.cc
@@ -78,7 +78,7 @@ Status RknpuUtils::GetPadType(rk::nn::PadType &rk_pad_type, int pad_type) {
     return TNN_OK;
 }
 
-uint32_t RknpuUtils::CalcSize(rk::nn::PrecisionType type, std::vector<uint32_t> dims) {
+uint32_t RknpuUtils::CalcSize(rk::nn::PrecisionType type, std::vector<int32_t> dims) {
     size_t type_size = 4;
     switch (type) {
         case rk::nn::PrecisionType::FLOAT32:

--- a/source/tnn/device/rknpu/convert/rknpu_utils.h
+++ b/source/tnn/device/rknpu/convert/rknpu_utils.h
@@ -37,7 +37,7 @@ public:
 
     static Status GetPadType(rk::nn::PadType &rk_pad_type, int pad_type);
 
-    static uint32_t CalcSize(rk::nn::PrecisionType type, std::vector<uint32_t> dims);
+    static uint32_t CalcSize(rk::nn::PrecisionType type, std::vector<int32_t> dims);
 };
 
 }  // namespace TNN_NS

--- a/source/tnn/device/rknpu/rknpu_model_interpreter.cc
+++ b/source/tnn/device/rknpu/rknpu_model_interpreter.cc
@@ -1,0 +1,31 @@
+// Tencent is pleased to support the open source community by making TNN available.
+//
+// Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "tnn/interpreter/abstract_model_interpreter.h"
+
+namespace TNN_NS {
+
+class RknpuModelInterpreter : public AbstractModelInterpreter {
+public:
+    RknpuModelInterpreter(){};
+    ~RknpuModelInterpreter(){};
+    Status Interpret(std::vector<std::string> &params) {
+        return TNN_OK;
+    }
+};
+
+TypeModelInterpreterRegister<TypeModelInterpreterCreator<RknpuModelInterpreter>> g_atlas_model_interpreter_register(
+    MODEL_TYPE_RKCACHE);
+
+}  // namespace TNN_NS

--- a/source/tnn/device/rknpu/rknpu_network.h
+++ b/source/tnn/device/rknpu/rknpu_network.h
@@ -108,6 +108,8 @@ private:
     Status GetOutputShapeMap(NetworkConfig &net_config, AbstractModelInterpreter *interpreter,
                              InputShapesMap &input_shape, OutputShapesMap &output_shape);
 
+    Status InitCacheGraph(std::string &cache_path, rk::nn::Graph *graph);
+
     AbstractDevice *device_ = nullptr;
 
     Context *context_ = nullptr;

--- a/source/tnn/device/rknpu/tnn_impl_rknpu.cc
+++ b/source/tnn/device/rknpu/tnn_impl_rknpu.cc
@@ -1,0 +1,52 @@
+// Tencent is pleased to support the open source community by making TNN available.
+//
+// Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "tnn/device/rknpu/tnn_impl_rknpu.h"
+#include "tnn/core/instance.h"
+#include "tnn/interpreter/abstract_model_interpreter.h"
+
+namespace TNN_NS {
+
+TNNImplRknpu::TNNImplRknpu() {}
+
+TNNImplRknpu::~TNNImplRknpu() {}
+
+Status TNNImplRknpu::Init(ModelConfig& config) {
+    TNNImpl::Init(config);
+    auto interpreter = CreateModelInterpreter(config.model_type);
+    if (!interpreter) {
+        return Status(TNNERR_NET_ERR, "interpreter is nil");
+    }
+    interpreter_ = std::shared_ptr<AbstractModelInterpreter>(interpreter);
+    return interpreter_->Interpret(config.params);
+}
+
+Status TNNImplRknpu::DeInit() {
+    return TNN_OK;
+}
+
+Status TNNImplRknpu::AddOutput(const std::string& layer_name, int output_index) {
+    return TNN_OK;
+}
+
+std::shared_ptr<Instance> TNNImplRknpu::CreateInst(NetworkConfig& net_config, Status& status,
+                                                   InputShapesMap inputs_shape) {
+    auto instance = std::make_shared<Instance>(net_config, model_config_);
+    status        = instance->Init(interpreter_, inputs_shape);
+    return instance;
+}
+
+TNNImplFactoryRegister<TNNImplFactory<TNNImplRknpu>> g_tnn_impl_atlas_factory_register(MODEL_TYPE_RKCACHE);
+
+}  // namespace TNN_NS

--- a/source/tnn/device/rknpu/tnn_impl_rknpu.h
+++ b/source/tnn/device/rknpu/tnn_impl_rknpu.h
@@ -1,0 +1,65 @@
+// Tencent is pleased to support the open source community by making TNN available.
+//
+// Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef TNN_SOURCE_DEVICE_RKNPU_TNN_IMPL_RKNPU_H_
+#define TNN_SOURCE_DEVICE_RKNPU_TNN_IMPL_RKNPU_H_
+
+#include "tnn/core/macro.h"
+#include "tnn/core/tnn_impl.h"
+
+namespace TNN_NS {
+
+// @brief tnn impl with interpreter
+class TNNImplRknpu : public TNNImpl {
+public:
+    // @brief tnn constructor
+    TNNImplRknpu();
+
+    // @brief tnn destructor
+    virtual ~TNNImplRknpu();
+
+    // @brief init the tnn, contruct model interpreter
+    // @param config config model type and params
+    // @return status code: Successful, returns zero. Otherwise, returns
+    // error code.
+    virtual Status Init(ModelConfig& config);
+
+    // @brief release model interpreter
+    virtual Status DeInit();
+
+    //@brief Adds output to the layer. If layerName not found, then search
+    // outputIndex.
+    //@param output_name Name of the output blob
+    //@param output_index Index of the output layer
+    //@return status code: If successful, returns zero. Otherwise, returns
+    // error
+    // code.
+    virtual Status AddOutput(const std::string& output_name, int output_index = 0);
+
+    // @brief create an instance
+    // @param instance: The instance to be created.
+    // @param inputs_shape: modify input shape, or it will use the shape in the
+    // proto
+    // @param status code: If successful, returns zero. Otherwise, returns
+    // error code.
+    virtual std::shared_ptr<Instance> CreateInst(NetworkConfig& config, Status& status,
+                                                 InputShapesMap inputs_shape = InputShapesMap());
+
+private:
+    std::shared_ptr<AbstractModelInterpreter> interpreter_;
+};
+
+}
+
+#endif

--- a/test/flags.h
+++ b/test/flags.h
@@ -22,7 +22,7 @@ namespace TNN_NS {
 
 static const char help_message[] = "print a usage message.";
 
-static const char model_type_message[] = "specify model type: TNN, OPENVINO, COREML, SNPE, NCNN.";
+static const char model_type_message[] = "specify model type: TNN, OPENVINO, COREML, SNPE, NCNN, RKCACHE.";
 
 static const char model_path_message[] =
     "specify model path: tnn proto path, openvino xml path, coreml "

--- a/test/test_utils.cc
+++ b/test/test_utils.cc
@@ -48,6 +48,8 @@ ModelType ConvertModelType(std::string model_type) {
         return MODEL_TYPE_COREML;
     } else if ("NCNN" == model_type) {
         return MODEL_TYPE_NCNN;
+    } else if ("RKCACHE" == model_type) {
+        return MODEL_TYPE_RKCACHE;
     } else {
         return MODEL_TYPE_TNN;
     }


### PR DESCRIPTION
1. 传入tnn模型时，设置cache_path，可以生成cache model，编译时间长占用内存高
2. 第二次可以直接传入cache model，但需要设置model type为RKCHACHE