### PR TITLE
Dev issue 695

### DIFF
--- a/tools/convert2tnn/caffe_converter/caffe2tnn.py
+++ b/tools/convert2tnn/caffe_converter/caffe2tnn.py
@@ -22,6 +22,8 @@ from converter import logging
 
 import os
 import sys
+import time
+
 
 def caffe2onnx(proto_path, model_path, output_path):
     work_dir = "../caffe2onnx/"
@@ -34,7 +36,7 @@ def caffe2onnx(proto_path, model_path, output_path):
 
 
 def convert(proto_path, model_path, output_dir, version, optimize, half, align=False,
-            input_path=None, refer_path=None):
+            input_path=None, refer_path=None, debug_mode: bool = False):
     logging.info("Converter Caffe to ONNX Model\n")
     checker.check_file_exist(proto_path)
     checker.check_file_exist(model_path)
@@ -52,7 +54,7 @@ def convert(proto_path, model_path, output_dir, version, optimize, half, align=F
     else:
         logging.info("Congratulations! caffe2onnx succeed!\n")
     if version is None:
-        version = "v1.0"
+        version = time.strftime('%Y%m%d%H%M', time.localtime())
 
     is_ssd = checker.is_ssd_model(proto_path)
     if is_ssd:
@@ -76,4 +78,4 @@ def convert(proto_path, model_path, output_dir, version, optimize, half, align=F
             tnn_model_name = onnx_base_name[:-len('.onnx')] + model_suffix
         tnn_proto_path = os.path.join(output_dir, tnn_proto_name)
         tnn_model_path = os.path.join(output_dir, tnn_model_name)
-        align_model.align_model(onnx_path, tnn_proto_path, tnn_model_path, input_path, refer_path)
+        align_model.align_model(onnx_path, tnn_proto_path, tnn_model_path, input_path, refer_path, debug_mode=debug_mode)

--- a/tools/convert2tnn/converter.py
+++ b/tools/convert2tnn/converter.py
@@ -21,14 +21,18 @@ from tf_converter import tf2tnn
 from tflite_converter import tflite2tnn
 from utils import parse_path
 
-logging.basicConfig(level=logging.INFO, format="")
-
 
 def main():
     parser = args_parser.parse_args()
     args = parser.parse_args()
 
+    debug_mode: bool = args.debug
+    if debug_mode is True:
+        logging.basicConfig(level=logging.DEBUG, format='')
+    else:
+        logging.basicConfig(level=logging.INFO, format='')
     logging.info("\n{}  convert model, please wait a moment {}\n".format("-" * 10, "-" * 10))
+
     if args.sub_command == 'onnx2tnn':
         onnx_path = parse_path.parse_path(args.onnx_path)
         output_dir = parse_path.parse_path(args.output_dir)
@@ -47,11 +51,12 @@ def main():
             input_names = ""
             for item in args.input_names:
                 input_names += (item + " ")
-
         try:
-            onnx2tnn.convert(onnx_path, output_dir, version, optimize, half, align, input_file, ref_file, input_names)
+            onnx2tnn.convert(onnx_path, output_dir, version, optimize, half, align, input_file, ref_file, input_names,
+                             debug_mode=debug_mode)
         except Exception as err:
             logging.error("Conversion to  tnn failed :(\n")
+            logging.error(err)
     
     elif args.sub_command == 'caffe2tnn':
         proto_path = parse_path.parse_path(args.proto_path)
@@ -66,9 +71,11 @@ def main():
         input_file = parse_path.parse_path(input_file)
         ref_file = parse_path.parse_path(ref_file)
         try:
-            caffe2tnn.convert(proto_path, model_path, output_dir, version, optimize, half, align, input_file, ref_file)
+            caffe2tnn.convert(proto_path, model_path, output_dir, version, optimize, half, align, input_file, ref_file,
+                              debug_mode=debug_mode)
         except Exception as err:
             logging.error("Conversion to  tnn failed :(\n")
+            logging.error(err)
 
     elif args.sub_command == 'tf2tnn':
         tf_path = parse_path.parse_path(args.tf_path)
@@ -84,12 +91,12 @@ def main():
         ref_file = args.refer_file_path
         input_file = parse_path.parse_path(input_file)
         ref_file = parse_path.parse_path(ref_file)
-
         try:
             tf2tnn.convert(tf_path, input_names, output_names, output_dir, version, optimize, half, align, not_fold_const,
-                        input_file, ref_file)
+                        input_file, ref_file, debug_mode=debug_mode)
         except Exception as err:
             logging.error("\nConversion to  tnn failed :(\n")
+            logging.error(err)
     elif args.sub_command == 'tflite2tnn':
         tf_path = parse_path.parse_path(args.tf_path)
         output_dir = parse_path.parse_path(args.output_dir)
@@ -100,10 +107,10 @@ def main():
         input_file = parse_path.parse_path(input_file)
         ref_file = parse_path.parse_path(ref_file)
         try:
-            tflite2tnn.convert(tf_path,  output_dir, version, align,
-                       input_file, ref_file)
+            tflite2tnn.convert(tf_path,  output_dir, version, align, input_file, ref_file, debug_mode=debug_mode)
         except Exception as err:
            logging.error("\n Conversion to  tnn failed :(\n")
+           logging.error(err)
     elif args.sub_command is None:
         parser.print_help()
     else:

--- a/tools/convert2tnn/onnx_converter/onnx2tnn.py
+++ b/tools/convert2tnn/onnx_converter/onnx2tnn.py
@@ -56,7 +56,7 @@ def check_input_names(input_names: str, onnx_input_info: dict):
 
 
 def convert(onnx_path, output_dir=None, version="v1.0", optimize=True, half=False, align=False,
-            input_path=None, refer_path=None, input_names: str=None, is_ssd=False):
+            input_path=None, refer_path=None, input_names: str = None, is_ssd=False, debug_mode: bool = False):
     """
     执行 onnx 转换为 tnn 的转换指令
     :parameter:
@@ -85,7 +85,7 @@ def convert(onnx_path, output_dir=None, version="v1.0", optimize=True, half=Fals
     proto_suffix = '.tnnproto'
     model_suffix = '.tnnmodel'
     command = "python3 onnx2tnn.py " + onnx_path
-    command = command + " -version=v1.0"
+    command = command + " -version=" + version
     checker.check_file_exist(onnx_path)
     if optimize is True:
         command = command + " -optimize=1"
@@ -126,6 +126,8 @@ def convert(onnx_path, output_dir=None, version="v1.0", optimize=True, half=Fals
         tnn_model_path = os.path.join(output_dir, tnn_model_name)
 
         if input_names is None:
-            align_model.align_model(onnx_path, tnn_proto_path, tnn_model_path, input_path, refer_path)
+            align_model.align_model(onnx_path, tnn_proto_path, tnn_model_path, input_path, refer_path,
+                                    debug_mode=debug_mode)
         else:
-            align_model.align_model(onnx_path, tnn_proto_path, tnn_model_path, input_path, refer_path, input_names)
+            align_model.align_model(onnx_path, tnn_proto_path, tnn_model_path, input_path, refer_path, input_names,
+                                    debug_mode=debug_mode)

--- a/tools/convert2tnn/tf_converter/tf2tnn.py
+++ b/tools/convert2tnn/tf_converter/tf2tnn.py
@@ -23,6 +23,7 @@ from converter import logging
 
 import os
 import sys
+import time
 
 
 def hack_name(names: str):
@@ -80,7 +81,7 @@ def tf2onnx(tf_path, input_names, output_name, onnx_path, not_fold_const=False):
 
 
 def convert(tf_path, input_names, output_names, output_dir, version, optimize, half, align=False, not_fold_const=False,
-            input_path=None, refer_path=None):
+            input_path=None, refer_path=None, debug: bool = False, debug_mode: bool = False):
     logging.info("Converter Tensorflow to TNN model\n")
     checker.check_file_exist(tf_path)
     model_name = os.path.basename(tf_path)
@@ -95,7 +96,7 @@ def convert(tf_path, input_names, output_names, output_dir, version, optimize, h
     else:
         logging.info("Convert TensorFlow to ONNX model succeed!\n")
     if version is None:
-        version = "v1.0"
+        version = time.strftime('%Y%m%d%H%M', time.localtime())
     checker.check_file_exist(onnx_path)
     onnx2tnn.convert(onnx_path, output_dir, version, optimize, half)
     if align is True:
@@ -110,7 +111,7 @@ def convert(tf_path, input_names, output_names, output_dir, version, optimize, h
             tnn_model_name = onnx_base_name[:-len('.onnx')] + model_suffix
         tnn_proto_path = os.path.join(output_dir, tnn_proto_name)
         tnn_model_path = os.path.join(output_dir, tnn_model_name)
-        align_model.align_model(onnx_path, tnn_proto_path, tnn_model_path, input_path, refer_path)
+        align_model.align_model(onnx_path, tnn_proto_path, tnn_model_path, input_path, refer_path, debug_mode=debug_mode)
 
     onnx_base_name = os.path.basename(onnx_path)
     tnn_proto_name = onnx_base_name[:-len('.onnx')] + ('.opt.tnnproto' if optimize else ".tnnproto")

--- a/tools/convert2tnn/tflite_converter/tflite2tnn.py
+++ b/tools/convert2tnn/tflite_converter/tflite2tnn.py
@@ -43,7 +43,7 @@ def tflite2tnn(tf_path, tnn_path, not_fold_const=False):
 
 
 def convert(tf_path,  output_dir, version,  align=False,
-            input_path=None, refer_path=None):
+            input_path=None, refer_path=None, debug_mode: bool = False):
     checker.check_file_exist(tf_path)
     model_name = os.path.basename(tf_path)
     if output_dir is None or not os.path.isdir(output_dir):
@@ -65,4 +65,5 @@ def convert(tf_path,  output_dir, version,  align=False,
         tnn_model_name = model_name + model_suffix
         tnn_proto_path = os.path.join(output_dir, tnn_proto_name)
         tnn_model_path = os.path.join(output_dir, tnn_model_name)
-        align_model.align_model(tf_path, tnn_proto_path, tnn_model_path, input_path, refer_path, None, True)
+        align_model.align_model(tf_path, tnn_proto_path, tnn_model_path, input_path, refer_path, None, True,
+                                debug_mode=debug_mode)

--- a/tools/convert2tnn/utils/align_model.py
+++ b/tools/convert2tnn/utils/align_model.py
@@ -249,8 +249,8 @@ def replace_tnn_input_name(input_info: dict):
     return new_input_info
 
 
-def align_model(onnx_path: str, tnn_proto_path: str, tnn_model_path: str, input_file_path: str=None,
-                refer_path: str = None, input_names: str = None, is_tflite: bool=False ) -> bool:
+def align_model(onnx_path: str, tnn_proto_path: str, tnn_model_path: str, input_file_path: str = None,
+                refer_path: str = None, input_names: str = None, is_tflite: bool = False, debug_mode: bool = False) -> bool:
     """
     对 onnx 模型和 tnn 模型进行对齐.
     当前支持模型: 单输入,单输出;单输入,多输出;
@@ -300,9 +300,9 @@ def align_model(onnx_path: str, tnn_proto_path: str, tnn_model_path: str, input_
             logging.error("Invalid refer_path")
             sys.exit(return_code.ALIGN_FAILED)
     run_tnn_model_check(tnn_proto_path, tnn_model_path, input_path, reference_output_path, is_tflite)
-    if input_file_path is None and os.path.exists(input_path):
-        data.clean_temp_data(os.path.dirname(input_path))
-    if refer_path is None and os.path.exists(reference_output_path):
-        data.clean_temp_data(reference_output_path)
-
+    if debug_mode is False:
+        if input_file_path is None and os.path.exists(input_path):
+            data.clean_temp_data(os.path.dirname(input_path))
+        if refer_path is None and os.path.exists(reference_output_path):
+            data.clean_temp_data(reference_output_path)
     return True

--- a/tools/convert2tnn/utils/args_parser.py
+++ b/tools/convert2tnn/utils/args_parser.py
@@ -13,12 +13,12 @@
 # specific language governing permissions and limitations under the License.
 
 import argparse
+import time
 
 
 def parse_args():
     parser = argparse.ArgumentParser(prog='convert',
                                      description='convert ONNX/Tensorflow/Tensorflowlite/Caffe model to TNN model')
-
     subparsers = parser.add_subparsers(dest="sub_command")
 
     onnx2tnn_parser = subparsers.add_parser('onnx2tnn',
@@ -49,7 +49,7 @@ def parse_args():
     onnx2tnn_parser.add_argument('-v',
                                  metavar="v1.0.0",
                                  dest='version',
-                                 default="v1.0.0",
+                                 default=time.strftime('%Y%m%d%H%M', time.localtime()),
                                  action='store',
                                  required=False,
                                  help="the version for model")
@@ -79,7 +79,7 @@ def parse_args():
                                 default=False,
                                 action='store_true',
                                 required=False,
-                                help=argparse.SUPPRESS)
+                                help="Turn on the switch to debug the model.")
 
     # convert caff2onnx -pp proto_path -mp model_path -o
     caffe2tnn_parser = subparsers.add_parser('caffe2tnn',
@@ -100,7 +100,7 @@ def parse_args():
     caffe2tnn_parser.add_argument('-v',
                                   metavar="v1.0",
                                   dest='version',
-                                  default="v1.0.0",
+                                  default=time.strftime('%Y%m%d%H%M', time.localtime()),
                                   action='store',
                                   required=False,
                                   help="the version for model, default v1.0")
@@ -137,7 +137,7 @@ def parse_args():
                                 default=False,
                                 action='store_true',
                                 required=False,
-                                help=argparse.SUPPRESS)
+                                help="Turn on the switch to debug the model.")
 
     tf2tnn_parser = subparsers.add_parser('tf2tnn',
                                           help="convert tensorflow model to tnn model")
@@ -170,7 +170,7 @@ def parse_args():
     tf2tnn_parser.add_argument('-v',
                                metavar="v1.0",
                                dest='version',
-                               default="v1.0.0",
+                               default=time.strftime('%Y%m%d%H%M', time.localtime()),
                                action='store',
                                required=False,
                                help="the version for model")
@@ -213,7 +213,7 @@ def parse_args():
                                 default=False,
                                 action='store_true',
                                 required=False,
-                                help=argparse.SUPPRESS)
+                                help="Turn on the switch to debug the model.")
     #tflie parser
     tflite2tnn_parser = subparsers.add_parser('tflite2tnn',
                                           help="convert tensorflow-lite model to tnn model")
@@ -230,7 +230,7 @@ def parse_args():
     tflite2tnn_parser.add_argument('-v',
                            metavar="v1.0",
                            dest='version',
-                           default="v1.0.0",
+                           default=time.strftime('%Y%m%d%H%M', time.localtime()),
                            action='store',
                            required=False,
                            help="the version for model")
@@ -261,5 +261,5 @@ def parse_args():
                            default=False,
                            action='store_true',
                            required=False,
-                           help=argparse.SUPPRESS)
+                           help="Turn on the switch to debug the model.")
     return parser

--- a/tools/convert2tnn/utils/cmd.py
+++ b/tools/convert2tnn/utils/cmd.py
@@ -42,14 +42,15 @@ def run(cmd_string, work_dir=None, timeout=None, is_shell=True):
 
     sub = subprocess.Popen(cmd_string_list,
                            stdout=subprocess.PIPE,
-                           stderr=subprocess.PIPE,
+                           stderr=subprocess.STDOUT,
                            shell=True,
-                           bufsize=4096,
+                           bufsize=0,
                            cwd=work_dir,
                            close_fds=True)
-    (stdout, stderr) = sub.communicate()
-    logging.debug(str(stdout.decode('utf-8')))
+    while True:
+        line = sub.stdout.readline().decode('utf-8')
+        logging.error(str(line))
+        if line == '' and sub.poll() is not None:
+            break
     rc = sub.poll()
-    if rc != 0:
-        logging.error(str(stderr.decode('utf-8')))
     return rc

--- a/tools/convert2tnn/utils/cmd.py
+++ b/tools/convert2tnn/utils/cmd.py
@@ -49,7 +49,7 @@ def run(cmd_string, work_dir=None, timeout=None, is_shell=True):
                            close_fds=True)
     while True:
         line = sub.stdout.readline().decode('utf-8')
-        logging.error(str(line))
+        logging.debug(str(line))
         if line == '' and sub.poll() is not None:
             break
     rc = sub.poll()


### PR DESCRIPTION
1. 目前 TNN 的 converter2tnn 工具对 model_check的日志处理不好，当 model_check crash 之后不能获取对应的日志。
2. 目前 converter2tnn 使用 v1.0 作为默认的 version 信息，修改为当前时间。
3. 优化下 converter2tnn 的日志开关, 修改成为通过“-debug” 参数进行控制。