### PR TITLE
修改了 Tensorflow 模型转换时 "-in" 参数的格式

### DIFF
--- a/doc/cn/user/convert.md
+++ b/doc/cn/user/convert.md
@@ -103,36 +103,34 @@ docker run  -it tnn-convert:latest  python3 ./converter.py tf2tnn -h
 ```
 得到的输出信息如下：
 ``` text
-usage: convert tf2tnn [-h] -tp TF_PATH -in input_name -on output_name
-                      [-o OUTPUT_DIR] [-v v1.0] [-optimize] [-half]
+usage: convert tf2tnn [-h] -tp TF_PATH -in input_info [input_info ...] -on output_name [output_name ...] [-o OUTPUT_DIR] [-v v1.0] [-optimize] [-half] [-align] [-input_file INPUT_FILE_PATH]
+                      [-ref_file REFER_FILE_PATH]
 
 optional arguments:
   -h, --help            show this help message and exit
   -tp TF_PATH           the path for tensorflow graphdef file
-  -in input_name        the tensorflow model's input names. If batch is not
-                        specified, you can add input shape after the input
-                        name, e.g. -in "name[1,28,28,3]"
-  -on output_name       the tensorflow model's output name
+  -in input_info [input_info ...]
+                        specify the input name and shape of the model. e.g., -in input1_name:1,128,128,3 input2_name:1,256,256,3
+  -on output_name [output_name ...]
+                        the tensorflow model's output name. e.g. -on output_name1 output_name2
   -o OUTPUT_DIR         the output tnn directory
   -v v1.0               the version for model
   -optimize             optimize the model
   -half                 optimize the model
   -align                align the onnx model with tnn model
   -input_file INPUT_FILE_PATH
-                        the input file path which contains the input data for
-                        the inference model.
+                        the input file path which contains the input data for the inference model.
   -ref_file REFER_FILE_PATH
-                        the reference file path which contains the reference
-                        data to compare the results.
+                        the reference file path which contains the reference data to compare the results.
 ```
 通过上面的输出，可以发现针对 TF 模型的转换，convert2tnn 工具提供了很多参数，我们一次对下面的参数进行解释：
 
 - tp 参数（必须）
     通过 “-tp” 参数指定需要转换的模型的路径。目前只支持单个 TF模型的转换，不支持多个 TF 模型的一起转换。
 - in 参数（必须）
-    通过 “-in” 参数指定模型输入的名称，输入的名称需要放到“”中，例如，-in "name"。如果模型有多个输入，请使用 “;”进行分割。有的 TensorFlow 模型没有指定 batch 导致无法成功转换为 ONNX 模型，进而无法成功转换为 TNN 模型。你可以通过在名称后添加输入 shape 进行指定。shape 信息需要放在 [] 中。例如：-in "name[1,28,28,3]"。
+    通过 “-in” 参数指定模型输入，输入的名称需要放到“”中，例如：-in input_name_1:1,128,128,3 input_name_2:1,256,256,3。
 - on 参数（必须）
-    通过 “-on” 参数指定模型输出的名称，如果模型有多个输出，请使用 “;”进行分割
+    通过 “-on” 参数指定模型输出的名称，例如: -on output_name1 output_name2
 - output_dir 参数：
     可以通过 “-o <path>” 参数指定输出路径，但是在 docker 中我们一般不使用这个参数，默认会将生成的 TNN 模型放在当前和 TF 模型相同的路径下。
 - optimize 参数（可选）
@@ -156,8 +154,8 @@ optional arguments:
 ``` shell script
 docker run --volume=$(pwd):/workspace -it tnn-convert:latest  python3 ./converter.py tf2tnn \
     -tp /workspace/test.pb \
-    -in "input0[1,32,32,3];input1[1,32,32,3]" \
-    -on output0 \
+    -in "input0:1,32,32,3 input2:1,32,32,3" \
+    -on output0 output1 \
     -v v2.0 \
     -optimize \
     -align \
@@ -332,10 +330,8 @@ python3 converter.py onnx2tnn -h
 ```
 usage 信息如下：
 ```text
-usage: convert onnx2tnn [-h] [-in input_name [input_name ...]] [-optimize]
-                        [-half] [-v v1.0.0] [-o OUTPUT_DIR] [-align]
-                        [-input_file INPUT_FILE_PATH]
-                        [-ref_file REFER_FILE_PATH]
+usage: convert onnx2tnn [-h] [-in input_info [input_info ...]] [-optimize] [-half] [-v v1.0.0] [-o OUTPUT_DIR] [-align]
+                        [-input_file INPUT_FILE_PATH] [-ref_file REFER_FILE_PATH]
                         onnx_path
 
 positional arguments:
@@ -343,20 +339,17 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -in input_name [input_name ...]
-                        specify the input name and shape of the model. e.g.,
-                        -in in1:1,3,8,8 in2:1,8
+  -in input_info [input_info ...]
+                        specify the input name and shape of the model. e.g., -in input1_name:1,3,8,8 input2_name:1,8
   -optimize             optimize the model
   -half                 save model using half
   -v v1.0.0             the version for model
   -o OUTPUT_DIR         the output tnn directory
   -align                align the onnx model with tnn model
   -input_file INPUT_FILE_PATH
-                        the input file path which contains the input data for
-                        the inference model.
+                        the input file path which contains the input data for the inference model.
   -ref_file REFER_FILE_PATH
-                        the reference file path which contains the reference
-                        data to compare the results.
+                        the reference file path which contains the reference data to compare the results.
 ```
 示例：
 ```shell script
@@ -439,28 +432,26 @@ python3 converter.py caffe2tnn \
 python3 converter.py tf2tnn -h
 ```
 usage 信息如下：
-```
-usage: convert tf2tnn [-h] -tp TF_PATH -in input_name -on output_name
-                      [-o OUTPUT_DIR] [-v v1.0] [-optimize] [-half]
+```text
+usage: convert tf2tnn [-h] -tp TF_PATH -in input_info [input_info ...] -on output_name [output_name ...] [-o OUTPUT_DIR] [-v v1.0] [-optimize] [-half] [-align] [-input_file INPUT_FILE_PATH]
+                      [-ref_file REFER_FILE_PATH]
 
 optional arguments:
   -h, --help            show this help message and exit
   -tp TF_PATH           the path for tensorflow graphdef file
-  -in input_name        the tensorflow model's input names. If batch is not
-                        specified, you can add input shape after the input
-                        name, e.g. -in "name[1,28,28,3]"
-  -on output_name       the tensorflow model's output name
+  -in input_info [input_info ...]
+                        specify the input name and shape of the model. e.g., -in input1_name:1,128,128,3 input2_name:1,256,256,3
+  -on output_name [output_name ...]
+                        the tensorflow model's output name. e.g. -on output_name1 output_name2
   -o OUTPUT_DIR         the output tnn directory
   -v v1.0               the version for model
   -optimize             optimize the model
   -half                 optimize the model
   -align                align the onnx model with tnn model
   -input_file INPUT_FILE_PATH
-                        the input file path which contains the input data for
-                        the inference model.
+                        the input file path which contains the input data for the inference model.
   -ref_file REFER_FILE_PATH
-                        the reference file path which contains the reference
-                        data to compare the results.
+                        the reference file path which contains the reference data to compare the results.
 ```
 - tensorflow-lite2tnn
 

--- a/doc/cn/user/convert.md
+++ b/doc/cn/user/convert.md
@@ -128,7 +128,7 @@ optional arguments:
 - tp 参数（必须）
     通过 “-tp” 参数指定需要转换的模型的路径。目前只支持单个 TF模型的转换，不支持多个 TF 模型的一起转换。
 - in 参数（必须）
-    通过 “-in” 参数指定模型输入，输入的名称需要放到“”中，例如：-in input_name_1:1,128,128,3 input_name_2:1,256,256,3。
+    通过 “-in” 参数指定模型输入，例如：-in input_name_1:1,128,128,3 input_name_2:1,256,256,3。
 - on 参数（必须）
     通过 “-on” 参数指定模型输出的名称，例如: -on output_name1 output_name2
 - output_dir 参数：

--- a/doc/en/user/convert_en.md
+++ b/doc/en/user/convert_en.md
@@ -103,31 +103,34 @@ docker run  -it tnn-convert:latest  python3 ./converter.py tf2tnn -h
 ```
 The output shows below：
 ``` text
-usage: convert tf2tnn [-h] -tp TF_PATH -in input_name -on output_name
-                      [-o OUTPUT_DIR] [-v v1.0] [-optimize] [-half]
+usage: convert tf2tnn [-h] -tp TF_PATH -in input_info [input_info ...] -on output_name [output_name ...] [-o OUTPUT_DIR] [-v v1.0] [-optimize] [-half] [-align] [-input_file INPUT_FILE_PATH]
+                      [-ref_file REFER_FILE_PATH]
 
 optional arguments:
-  -h, --help       show this help message and exit
-  -tp TF_PATH      the path for tensorflow graphdef file
-  -in input_name   the tensorflow model's input names
-  -on output_name  the tensorflow model's output name
-  -o OUTPUT_DIR    the output tnn directory
-  -v v1.0          the version for model
-  -optimize        optimize the model
-  -half            optimize the model
-  -align           align the onnx model with tnn model
-  -fold_const      enable tf constant_folding transformation before conversion
-  -input_file      the input file path which contains the input data for the inference model
-  -ref_file        the reference file path which contains the reference data to compare the results
+  -h, --help            show this help message and exit
+  -tp TF_PATH           the path for tensorflow graphdef file
+  -in input_info [input_info ...]
+                        specify the input name and shape of the model. e.g., -in input1_name:1,128,128,3 input2_name:1,256,256,3
+  -on output_name [output_name ...]
+                        the tensorflow model's output name. e.g. -on output_name1 output_name2
+  -o OUTPUT_DIR         the output tnn directory
+  -v v1.0               the version for model
+  -optimize             optimize the model
+  -half                 optimize the model
+  -align                align the onnx model with tnn model
+  -input_file INPUT_FILE_PATH
+                        the input file path which contains the input data for the inference model.
+  -ref_file REFER_FILE_PATH
+                        the reference file path which contains the reference data to compare the results.
 ```
 Here are the explanations for each parameter:
 
 - tp parameter (required)
     Use the "-tp" parameter to specify the path of the model to be converted. Currently only supports the conversion of a single TF model, does not support the conversion of multiple TF models together.
 - in parameter (required)
-    Specify the name of the model input through the "-in" parameter. If the model has multiple inputs, use ";" to split. Some models specify placeholders with unknown ranks and dims which can not be mapped to onnx. In those cases one can add the shape after the input name inside [], for example -in name[1,28,28,3]
+    Specify the name of the model input through the "-in" parameter, for example "-in input1_name:1,128,128,3 input2_name:1,256,256,3"
 - on parameter (required)
-    Specify the name of the model output through the "-on" parameter. If the model has multiple outputs, use ";" to split
+    Specify the name of the model output through the "-on" parameter, for example "-on output_name1 output_name2"
 - output_dir parameter:
     You can specify the output path through the "-o <path>" parameter, but we generally do not apply this parameter in docker. By default, the generated TNN model will be placed in the same path as the TF model.
 - optimize parameter (optional)
@@ -317,21 +320,26 @@ python3 converter.py onnx2tnn -h
 ```
 usage information：
 ```text
-usage: convert onnx2tnn [-h] [-optimize] [-half] [-v v1.0.0] [-o OUTPUT_DIR]
+usage: convert onnx2tnn [-h] [-in input_info [input_info ...]] [-optimize] [-half] [-v v1.0.0] [-o OUTPUT_DIR] [-align]
+                        [-input_file INPUT_FILE_PATH] [-ref_file REFER_FILE_PATH]
                         onnx_path
 
 positional arguments:
-  onnx_path      the path for onnx file
+  onnx_path             the path for onnx file
 
 optional arguments:
   -h, --help            show this help message and exit
+  -in input_info [input_info ...]
+                        specify the input name and shape of the model. e.g., -in input1_name:1,3,8,8 input2_name:1,8
   -optimize             optimize the model
   -half                 save model using half
   -v v1.0.0             the version for model
   -o OUTPUT_DIR         the output tnn directory
   -align                align the onnx model with tnn model
-  -input_file in.txt    the input file path which contains the input data for the inference model
-  -ref_file   ref.txt   the reference file path which contains the reference data to compare the results
+  -input_file INPUT_FILE_PATH
+                        the input file path which contains the input data for the inference model.
+  -ref_file REFER_FILE_PATH
+                        the reference file path which contains the reference data to compare the results.
 ```
 Example:
 ```shell script
@@ -397,23 +405,26 @@ The current convert2tnn model only supports the graphdef model, but does not sup
 python3 converter.py tf2tnn -h
 ```
 usage information：
-```
-usage: convert tf2tnn [-h] -tp TF_PATH -in input_name -on output_name
-                      [-o OUTPUT_DIR] [-v v1.0] [-optimize] [-half]
+```text
+usage: convert tf2tnn [-h] -tp TF_PATH -in input_info [input_info ...] -on output_name [output_name ...] [-o OUTPUT_DIR] [-v v1.0] [-optimize] [-half] [-align] [-input_file INPUT_FILE_PATH]
+                      [-ref_file REFER_FILE_PATH]
 
 optional arguments:
   -h, --help            show this help message and exit
   -tp TF_PATH           the path for tensorflow graphdef file
-  -in input_name        the tensorflow model's input names
-  -on output_name       the tensorflow model's output name
+  -in input_info [input_info ...]
+                        specify the input name and shape of the model. e.g., -in input1_name:1,128,128,3 input2_name:1,256,256,3
+  -on output_name [output_name ...]
+                        the tensorflow model's output name. e.g. -on output_name1 output_name2
   -o OUTPUT_DIR         the output tnn directory
   -v v1.0               the version for model
   -optimize             optimize the model
   -half                 optimize the model
   -align                align the onnx model with tnn model
-  -fold_const           enable tf constant_folding transformation before conversion
-  -input_file in.txt    the input file path which contains the input data for the inference model
-  -ref_file   out.txt   the reference file path which contains the reference data to compare the results
+  -input_file INPUT_FILE_PATH
+                        the input file path which contains the input data for the inference model.
+  -ref_file REFER_FILE_PATH
+                        the reference file path which contains the reference data to compare the results.
 ```
 Example：
 ```shell script

--- a/tools/convert2tnn/tf_converter/tf2tnn.py
+++ b/tools/convert2tnn/tf_converter/tf2tnn.py
@@ -25,45 +25,39 @@ import os
 import sys
 
 
-def hack_name(names: str):
+def hack_name(names: list):
     hacked_names = ""
-    name_list = names.split(';')
-    for name in name_list:
+    for name in names:
         if name.endswith(":0"):
             hacked_names = hacked_names + name + ","
         else:
             hacked_names = hacked_names + name + ":0,"
     return hacked_names[:-1]
 
-def process_input_names(input_names : str):
-    split = input_names.split(";")
-    name_list = []
-    shape_list = []
-    for item in split:
-        temp = item.split("[")
-        if not temp[0].endswith(":0"):
-            temp[0] += ":0"
-        name_list.append(temp[0])
-        if len(temp) > 1:
-            shape_list.append("[" + temp[1])
-        else:
-            shape_list.append("")
 
-    inputs = ""
-    inputs_as_nchw = ""
-    for name, shape in zip(name_list, shape_list):
-        inputs += (name + shape + ",")
-        inputs_as_nchw += (name + ",")
+def format_input(arguments: list) -> dict:
+    format_input_info: dict = {}
+    for item in arguments:
+        position = item.rfind(':')
+        name, dims = item[0:position], item[position+1:]
+        if not name.endswith(':0'):
+            name += ':0'
+        dims = '[' + dims + ']'
+        format_input_info.update({name: dims})
+    return format_input_info
 
-    return inputs[:-1], inputs_as_nchw[:-1]
 
 def tf2onnx(tf_path, input_names, output_name, onnx_path, not_fold_const=False):
     work_dir = "./"
-    inputs, inputs_as_nchw = process_input_names(input_names)
+    input_info: dict = format_input(input_names)
+    input_info_str: str = ""
+    input_nchw_names: str = ""
+    for item in input_info.items():
+        input_info_str += item[0] + item[1] + ","
+        input_nchw_names += item[0] + ","
     command = "python3 -m tf2onnx.convert  --graphdef " + tf_path
-
-    command = command + " --inputs " + inputs
-    command = command + " --inputs-as-nchw " + inputs_as_nchw
+    command = command + " --inputs " + input_info_str
+    command = command + " --inputs-as-nchw " + input_nchw_names
 
     command = command + " --outputs " + hack_name(output_name)
     command = command + " --output " + onnx_path

--- a/tools/convert2tnn/utils/args_parser.py
+++ b/tools/convert2tnn/utils/args_parser.py
@@ -27,13 +27,14 @@ def parse_args():
                                  action='store',
                                  help="the path for onnx file")
     onnx2tnn_parser.add_argument('-in',
-                                 metavar='input_name',
+                                 metavar='input_info',
                                  dest='input_names',
                                  action='store',
                                  required=False,
                                  nargs='+',
                                  type=str,
-                                 help="specify the input name and shape of the model. e.g., -in in1:1,3,8,8 in2:1,8")
+                                 help="specify the input name and shape of the model. e.g., " +
+                                      "-in input1_name:1,3,8,8 input2_name:1,8")
     onnx2tnn_parser.add_argument('-optimize',
                                  dest='optimize',
                                  default=False,
@@ -148,18 +149,22 @@ def parse_args():
                                help="the path for tensorflow graphdef file")
 
     tf2tnn_parser.add_argument('-in',
-                               metavar='input_name',
+                               metavar='input_info',
                                dest='input_names',
                                action='store',
+                               nargs='+',
+                               type=str,
                                required=True,
-                               help="the tensorflow model's input names. If batch is not specified, you can add input shape after the input name, e.g. -in \"name[1,28,28,3]\"")
-
+                               help="specify the input name and shape of the model. e.g., " +
+                                      "-in input1_name:1,128,128,3 input2_name:1,256,256,3")
     tf2tnn_parser.add_argument('-on',
                                metavar='output_name',
                                dest='output_names',
                                action='store',
                                required=True,
-                               help="the tensorflow model's output name")
+                               nargs='+',
+                               type=str,
+                               help="the tensorflow model's output name. e.g. -on output_name1 output_name2")
 
     tf2tnn_parser.add_argument('-o',
                                dest='output_dir',


### PR DESCRIPTION
1. 修改了 Tensorflow 模型转换时 "-in" 参数的格式
    older format:  -in="input1_name[1,128,128,3];input2_name[1,256,256,3]" 
    new format： -in input1_name:1,128,128,3 input2_name:1,256,256,3
2. 更新了对应的文档