### PR TITLE
[OPENCL] optimize blob converter scale bias copy && kernel create

### DIFF
--- a/source/tnn/device/opencl/opencl_blob_converter.h
+++ b/source/tnn/device/opencl/opencl_blob_converter.h
@@ -52,6 +52,8 @@ private:
     std::shared_ptr<cl::Buffer> buffer_ = nullptr;
     std::shared_ptr<cl::Buffer> scale_buffer_ = nullptr;
     std::shared_ptr<cl::Buffer> bias_buffer_ = nullptr;
+    std::vector<float> host_scale_buffer_;
+    std::vector<float> host_bias_buffer_;
     int buffer_size_ = 0;
     int scale_bias_buffer_size_ = 0;
     bool do_scale_bias_ = true;

--- a/source/tnn/device/opencl/opencl_utils.cc
+++ b/source/tnn/device/opencl/opencl_utils.cc
@@ -461,17 +461,10 @@ Status CopyBufferToMat(Mat &mat, cl::Buffer& buffer, DimsVector& dims, const int
         return Status(TNNERR_OPENCL_MEMALLOC_ERROR, "OpenCL buffer is smaller than the need!");
     }
     cl_int ret = CL_SUCCESS;
-    auto output_buffer_ptr =
-        command_queue->enqueueMapBuffer(buffer, true, CL_MAP_WRITE, 0, buffer_size, nullptr, nullptr, &ret);
+    ret = command_queue->enqueueReadBuffer(buffer, CL_TRUE, 0, size_in_bytes, mat.GetData());
     if (ret != CL_SUCCESS) {
         CHECK_CL_SUCCESS(ret)
-        return Status(TNNERR_OPENCL_MEMMAP_ERROR, "OpenCL MemMap failed");
-    }
-    memcpy(mat.GetData(), output_buffer_ptr, size_in_bytes);
-    ret = command_queue->enqueueUnmapMemObject(buffer, output_buffer_ptr);
-    if (ret != CL_SUCCESS) {
-        CHECK_CL_SUCCESS(ret)
-        return Status(TNNERR_OPENCL_MEMUNMAP_ERROR, "OpenCL MemUnMap falied");
+        return Status(TNNERR_OPENCL_MEMUNMAP_ERROR, "OpenCL enqueueReadBuffer falied");
     }
 
     return TNN_OK;
@@ -491,17 +484,10 @@ Status CopyMatToBuffer(Mat &mat, cl::Buffer& buffer, DimsVector& dims, const int
         return Status(TNNERR_OPENCL_MEMALLOC_ERROR, "OpenCL buffer is smaller than the need!");
     }
     cl_int ret = CL_SUCCESS;
-    auto output_buffer_ptr =
-        command_queue->enqueueMapBuffer(buffer, true, CL_MAP_WRITE, 0, buffer_size, nullptr, nullptr, &ret);
+    ret = command_queue->enqueueWriteBuffer(buffer, CL_TRUE, 0, size_in_bytes, mat.GetData());
     if (ret != CL_SUCCESS) {
         CHECK_CL_SUCCESS(ret)
-        return Status(TNNERR_OPENCL_MEMMAP_ERROR, "OpenCL MemMap failed");
-    }
-    memcpy(output_buffer_ptr, mat.GetData(), size_in_bytes);
-    ret = command_queue->enqueueUnmapMemObject(buffer, output_buffer_ptr);
-    if (ret != CL_SUCCESS) {
-        CHECK_CL_SUCCESS(ret)
-        return Status(TNNERR_OPENCL_MEMUNMAP_ERROR, "OpenCL MemUnMap falied");
+        return Status(TNNERR_OPENCL_MEMUNMAP_ERROR, "OpenCL enqueueWriteBuffer falied");
     }
 
     return TNN_OK;


### PR DESCRIPTION
1. NCHW Mat转换Blob，需要将参数的scale和bias 拷贝到设备端的clBuffer，解决方法: CPU缓存当前的scale和bias，只有scale和bias改变，才去做设备端的拷贝
2. 修复重复创建Kernel的问题
3. 使用Write/Read Buffer替换Map/UnMap+memcpy