### PR TITLE
Fixed ddk link error

### DIFF
--- a/examples/android/demo/CMakeLists.txt
+++ b/examples/android/demo/CMakeLists.txt
@@ -88,6 +88,7 @@ target_link_libraries( # Specifies the target library.
                        ${log-lib})
 
 if(TNN_HUAWEI_NPU_ENABLE)
+    set(CMAKE_SHARED_LINKER_FLAGS "-fuse-ld=gold")  
     target_link_libraries( # Specifies the target library.
             tnn_wrapper hiai hiai_ir hiai_ir_build)
 endif()


### PR DESCRIPTION
Fixed ddk link error,
```
ld: error: found local symbol '__bss_start__' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai.so
ld: error: found local symbol '_bss_end__' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai.so
ld: error: found local symbol '_edata' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai.so
ld: error: found local symbol '__bss_end__' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai.so
ld: error: found local symbol '_end' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai.so
ld: error: found local symbol '__end__' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai.so
ld: error: found local symbol '__bss_start' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai.so
ld: error: found local symbol '__bss_start__' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir.so
ld: error: found local symbol '_bss_end__' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir.so
ld: error: found local symbol '_edata' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir.so
ld: error: found local symbol '__bss_end__' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir.so
ld: error: found local symbol '_end' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir.so
ld: error: found local symbol '__end__' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir.so
ld: error: found local symbol '__bss_start' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir.so
ld: error: found local symbol '__bss_start__' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir_build.so
ld: error: found local symbol '_bss_end__' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir_build.so
ld: error: found local symbol '_edata' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir_build.so
ld: error: found local symbol '__bss_end__' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir_build.so
ld: error: found local symbol '_end' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir_build.so
ld: error: found local symbol '__end__' in global part of symbol table in file ../../../../src/main/jni/thirdparty/hiai_ddk/arm64-v8a/libhiai_ir_build.so
```