### PR TITLE
[Metal][FIX] fix wrong directory in build_metal_lib

### DIFF
--- a/source/tnn/device/metal/build_tnn_metallib.sh
+++ b/source/tnn/device/metal/build_tnn_metallib.sh
@@ -14,7 +14,7 @@ TNNAllMetalFiles=()
 function FindAllMetalFiles()
 {
   # for file in `ls $1`　　　　　　
-   for file in $(ls $1)　
+   for file in $(ls $1)
    do
      if [ -d $1'/'$file ]; then
        FindAllMetalFiles $1'/'$file
@@ -33,7 +33,7 @@ function BuildMetalLib()
    #build air files
    for file in ${TNNAllMetalFiles[@]}
    do
-      echo "\033[32m       Compile ${file}\033[0m" 
+      echo "\033[32m       Compile ${file}\033[0m"
       # echo 'TNNMetalFloat32 = '${TNNMetalFloat32}
       xcrun -sdk macosx metal -std=osx-metal1.1 -DTNN_METAL_FULL_PRECISION -dM -I ${TNNMetalInclude} -c ${file} -o ${file}.air
       TNNAllMetalAIRFiles+=(${file}.air)


### PR DESCRIPTION
修复当metal/acc下ls最后一个文件为目录时，目录名称错误，导致该目录内的metal代码文件被编译忽略的问题
