### PR TITLE
1. fix bug for SpaceToDepth and DepthToSapce;

### DIFF
--- a/tools/onnx2tnn/src/core/onnx_fuse/onnx2tnn_fuse_depth_to_space.cc
+++ b/tools/onnx2tnn/src/core/onnx_fuse/onnx2tnn_fuse_depth_to_space.cc
@@ -14,7 +14,6 @@
 
 #include <math.h>
 
-
 #include "onnx2tnn.h"
 #include "onnx_utility.h"
 
@@ -93,6 +92,7 @@ int Onnx2TNN::FuseDepthToSpace(onnx::GraphProto* mutable_graph, std::vector<Inde
 
             onnx::AttributeProto* attr_mode = reshape_node->add_attribute();
             std::string mode                = is_crd ? "CRD" : "DCR";
+            attr_mode->set_name("mode");
             attr_mode->set_s(mode);
 
             node->set_op_type(k_tnn_noop_type);

--- a/tools/onnx2tnn/src/core/onnx_fuse/onnx2tnn_fuse_spacetodepth.cc
+++ b/tools/onnx2tnn/src/core/onnx_fuse/onnx2tnn_fuse_spacetodepth.cc
@@ -14,7 +14,6 @@
 
 #include <math.h>
 
-
 #include "onnx2tnn.h"
 #include "onnx_utility.h"
 
@@ -89,6 +88,7 @@ int Onnx2TNN::FuseSpaceToDepth(onnx::GraphProto* mutable_graph, std::vector<Inde
 
             onnx::AttributeProto* attr_mode = reshape_node->add_attribute();
             std::string mode                = is_crd ? "CRD" : "DCR";
+            attr_mode->set_name("mode");
             attr_mode->set_s(mode);
 
             node->set_op_type(k_tnn_noop_type);


### PR DESCRIPTION
1. 修复了 issue https://github.com/Tencent/TNN/issues/960
主要是在 Fuse SpaceToDepth 和 SpaceToDepth 两个算子时， attributes 没有设置名称。