### PR TITLE
解决 centos 7.2 编译 flatbuffers 失败的问题

### DIFF
--- a/third_party/flatbuffers/CMakeLists.txt
+++ b/third_party/flatbuffers/CMakeLists.txt
@@ -7,7 +7,7 @@ project(FlatBuffers)
 
 # NOTE: Code coverage only works on Linux & OSX.
 option(FLATBUFFERS_CODE_COVERAGE "Enable the code coverage build option." OFF)
-option(FLATBUFFERS_BUILD_TESTS "Enable the build of tests and samples." ON)
+option(FLATBUFFERS_BUILD_TESTS "Enable the build of tests and samples." OFF)
 option(FLATBUFFERS_INSTALL "Enable the installation of targets." ON)
 option(FLATBUFFERS_BUILD_FLATLIB "Enable the build of the flatbuffers library"
        ON)

--- a/tools/onnx2tnn/onnx-converter/build.sh
+++ b/tools/onnx2tnn/onnx-converter/build.sh
@@ -58,7 +58,6 @@ function build_onnx2tnn() {
     onnx2nn_files=$(ls -U tools/onnx2tnn/onnx-converter/onnx2tnn*.so);
     if [ ${#onnx2nn_files[*]} -ge 1 ]; then
         cp ${onnx2nn_files[i]} ../../../../../onnx-converter
-        rm ${onnx2nn_files[i]}
         echo "Compiled onnx2tnn successfully !"
     else
         echo "Compiled onnx2tnn failed !!!"


### PR DESCRIPTION
1. 解决 centos 7.2 编译 flatbuffers 失败的问题
2. 优化 onnx2tnn  编译脚本