### PR TITLE
1. support set tnn precision;

### DIFF
--- a/platforms/android/model_check_android.sh
+++ b/platforms/android/model_check_android.sh
@@ -19,9 +19,10 @@ INPUT_PATH=
 OPTION_DUMP_OUTPUT=
 OPTION_CHECK_BATCH=
 OPTION_CHECK_OUTPUT=
+SET_PRECISION=
 
 function usage() {
-    echo "usage: ./model_check_android.sh  [-32] [-v82] [-c] [-b] [-d] <device-id> [-t] <CPU/GPU> [-m] <tnnproto> [-i] <input_file> [-p] [-o]"
+    echo "usage: ./model_check_android.sh  [-32] [-v82] [-c] [-b] [-d] <device-id> [-t] <CPU/GPU> [-m] <tnnproto> [-i] <input_file> [-p] [-o] [-s <AUTO/...>]"
     echo "options:"
     echo "        -32   Build 32 bit."
     echo "        -v82  enable armv8.2."
@@ -34,7 +35,8 @@ function usage() {
     echo "        -p    Push models to device"
     echo "        -o    dump output"
     echo "        -a    check multi batch"
-    echo "        -e    only check output"
+    echo "        -e    only check output(precision: AUTO)"
+    echo "        -s    AUTO/NORMAL/HIGH/LOW specify the tnn precision(default: HIGH)"
 }
 function die() {
     echo $1
@@ -146,16 +148,16 @@ function run_android() {
 
         if [ -n "$INPUT_PATH" ]
         then
-            $ADB shell "cd $ANDROID_DIR ; LD_LIBRARY_PATH=$ANDROID_DIR:${ANDROID_DIR}/lib ./model_check -d $DEVICE -p $ANDROID_DATA_DIR/test.tnnproto -m $ANDROID_DATA_DIR/test.tnnmodel -i $ANDROID_DATA_DIR/input.txt $OPTION_DUMP_OUTPUT $OPTION_CHECK_BATCH $OPTION_CHECK_OUTPUT >> $ANDROID_DIR/test_log.txt"
+            $ADB shell "cd $ANDROID_DIR ; LD_LIBRARY_PATH=$ANDROID_DIR:${ANDROID_DIR}/lib ./model_check -d $DEVICE -p $ANDROID_DATA_DIR/test.tnnproto -m $ANDROID_DATA_DIR/test.tnnmodel -i $ANDROID_DATA_DIR/input.txt $OPTION_DUMP_OUTPUT $OPTION_CHECK_BATCH $OPTION_CHECK_OUTPUT $SET_PRECISION >> $ANDROID_DIR/test_log.txt"
         else
-            $ADB shell "cd $ANDROID_DIR ; LD_LIBRARY_PATH=$ANDROID_DIR:${ANDROID_DIR}/lib ./model_check -d $DEVICE -p $ANDROID_DATA_DIR/test.tnnproto -m $ANDROID_DATA_DIR/test.tnnmodel $OPTION_DUMP_OUTPUT $OPTION_CHECK_BATCH $OPTION_CHECK_OUTPUT >> $ANDROID_DIR/test_log.txt"
+            $ADB shell "cd $ANDROID_DIR ; LD_LIBRARY_PATH=$ANDROID_DIR:${ANDROID_DIR}/lib ./model_check -d $DEVICE -p $ANDROID_DATA_DIR/test.tnnproto -m $ANDROID_DATA_DIR/test.tnnmodel $OPTION_DUMP_OUTPUT $OPTION_CHECK_BATCH $OPTION_CHECK_OUTPUT $SET_PRECISION >> $ANDROID_DIR/test_log.txt"
         fi
     else
         if [ -n "$INPUT_PATH" ]
         then
-            $ADB shell "cd $ANDROID_DIR ; LD_LIBRARY_PATH=$ANDROID_DIR ./model_check -d $DEVICE -p $ANDROID_DATA_DIR/test.tnnproto -m $ANDROID_DATA_DIR/test.tnnmodel -i $ANDROID_DATA_DIR/input.txt $OPTION_DUMP_OUTPUT $OPTION_CHECK_BATCH $OPTION_CHECK_OUTPUT  >> $ANDROID_DIR/test_log.txt"
+            $ADB shell "cd $ANDROID_DIR ; LD_LIBRARY_PATH=$ANDROID_DIR ./model_check -d $DEVICE -p $ANDROID_DATA_DIR/test.tnnproto -m $ANDROID_DATA_DIR/test.tnnmodel -i $ANDROID_DATA_DIR/input.txt $OPTION_DUMP_OUTPUT $OPTION_CHECK_BATCH $OPTION_CHECK_OUTPUT $SET_PRECISION >> $ANDROID_DIR/test_log.txt"
         else
-            $ADB shell "cd $ANDROID_DIR ; LD_LIBRARY_PATH=$ANDROID_DIR ./model_check -d $DEVICE -p $ANDROID_DATA_DIR/test.tnnproto -m $ANDROID_DATA_DIR/test.tnnmodel $OPTION_DUMP_OUTPUT $OPTION_CHECK_BATCH $OPTION_CHECK_OUTPUT  >> $ANDROID_DIR/test_log.txt"
+            $ADB shell "cd $ANDROID_DIR ; LD_LIBRARY_PATH=$ANDROID_DIR ./model_check -d $DEVICE -p $ANDROID_DATA_DIR/test.tnnproto -m $ANDROID_DATA_DIR/test.tnnmodel $OPTION_DUMP_OUTPUT $OPTION_CHECK_BATCH $OPTION_CHECK_OUTPUT $SET_PRECISION >> $ANDROID_DIR/test_log.txt"
         fi
     fi
 
@@ -218,6 +220,11 @@ while [ "$1" != "" ]; do
         -e)
             shift
             OPTION_CHECK_OUTPUT=-e
+            ;;
+        -s)
+            shift
+            SET_PRECISION=" -sp $1"
+            shift
             ;;
         *)
             usage

--- a/tools/model_check/flags.cc
+++ b/tools/model_check/flags.cc
@@ -40,4 +40,6 @@ DEFINE_bool(b, false, check_batch_message);
 
 DEFINE_string(a, "", align_all_message);
 
+DEFINE_string(sp, "", set_precision_message);
+
 }  // namespace TNN_NS

--- a/tools/model_check/flags.h
+++ b/tools/model_check/flags.h
@@ -44,6 +44,8 @@ static const char check_batch_message[] = "(optional) check result of multi batc
 
 static const char align_all_message[] = "(optional) dump folder path to compare the all model";
 
+static const char set_precision_message[] = "(optional) specify tnn precision type(default HIGH): AUTO, NORMAL, HIGH, LOW";
+
 DECLARE_bool(h);
 
 DECLARE_string(p);
@@ -68,6 +70,7 @@ DECLARE_bool(b);
 
 DECLARE_string(a);
 
+DECLARE_string(sp);
 }  // namespace TNN_NS
 
 #endif  // TNN_TOOLS_MODEL_CHECK_FLAGS_H_

--- a/tools/model_check/main.cc
+++ b/tools/model_check/main.cc
@@ -65,6 +65,21 @@ DeviceType ConvertDeviceType(std::string device_type) {
     }
 }
 
+Precision ConvertPrecision(std::string precision) {
+    std::transform(precision.begin(), precision.end(), precision.begin(), ::toupper);
+    if ("AUTO" == precision) {
+        return PRECISION_AUTO;
+    } else if ("NORMAL" == precision) {
+        return PRECISION_NORMAL;
+    } else if ("HIGH" == precision) {
+        return PRECISION_HIGH;
+    } else if ("LOW" == precision) {
+        return PRECISION_LOW;
+    } else {
+        return PRECISION_HIGH;
+    }
+}
+
 int InitModelConfig(ModelConfig& model_config, std::string proto_file, std::string model_file) {
     {
         std::ifstream proto_stream(proto_file);
@@ -146,6 +161,7 @@ void ShowUsage() {
     printf("\t-o, <output>   \t%s\n", output_dump_message);
     printf("\t-b, <batch>    \t%s\n", check_batch_message);
     printf("\t-a, <align_all>\t%s\n", align_all_message);
+    printf("\t-sp, <set precision>\t%s\n", set_precision_message);
 }
 
 bool ParseAndCheckCommandLine(int argc, char* argv[]) {
@@ -267,12 +283,20 @@ int main(int argc, char* argv[]) {
         printf("set model_checker params failed! (error: %s)\n", status.description().c_str());
         return -1;
     }
-
-    if (model_checker_param.only_check_output) {
-        net_config.precision = PRECISION_AUTO;
+    if ("" == FLAGS_sp) {
+        if (model_checker_param.only_check_output) {
+            net_config.precision = PRECISION_AUTO;
+        } else {
+            net_config.precision = PRECISION_HIGH;
+        }
     } else {
-        net_config.precision = PRECISION_HIGH;
+        net_config.precision = ConvertPrecision(FLAGS_sp);
     }
+    // NPU devices always use PRECISION_AUTO
+    if (net_config.device_type == DEVICE_HUAWEI_NPU) {
+        net_config.precision = PRECISION_AUTO;
+    }
+    printf("tnn precision %d", net_config.precision);
     status = model_checker.Init(net_config, model_config);
     if (status != TNN_OK) {
         printf("model_checker init failed! (error: %s)\n", status.description().c_str());


### PR DESCRIPTION
1. model_check 工具支持了指定 tnn precision（精度）的功能
目前的逻辑：

> 不指定精度：NPU:AUTO;  check output only: AUTO; else: HIGHT

> 指定精度： NPU:AUTO;  else : 使用指定的精度
