### PR TITLE
[FIX] Fix building error with CUDA on Windows

### DIFF
--- a/source/tnn/network/tensorrt/shape_tensor.h
+++ b/source/tnn/network/tensorrt/shape_tensor.h
@@ -20,6 +20,12 @@
 #include <vector>
 
 #include <NvInfer.h>
+#ifdef _WIN32
+#include <numeric>
+#include <functional>
+#undef max
+#undef min
+#endif
 
 #include "tnn/core/macro.h"
 


### PR DESCRIPTION
When using min and max as function or variable name, windows system should be thought.