### PR TITLE
Fix the bug where the model check failed due to symbol ':'

### DIFF
--- a/tools/convert2tnn/utils/run_src_model.py
+++ b/tools/convert2tnn/utils/run_src_model.py
@@ -161,7 +161,7 @@ class BaseRunner:
                 shape = tnn_info['shape']
                 logging.info("Using tnn shape:{} for input:{}".format(shape,name))
             data_type = info['data_type']
-            data_file.write(name + ' ' + str(len(shape)) + ' ' + ' '.join([str(dim) for dim in shape]) + ' ' + str(
+            data_file.write(tnn_name + ' ' + str(len(shape)) + ' ' + ' '.join([str(dim) for dim in shape]) + ' ' + str(
                 data_type) + '\n')
             if data_type == 0:
                 self.input_data[name] = np.random.rand(*shape).astype(np.float32)

--- a/tools/model_check/model_checker.cc
+++ b/tools/model_check/model_checker.cc
@@ -215,6 +215,7 @@ Status ModelChecker::RunModelCheckerFromDumpFile() {
             auto replace_name    = blob_name;
 
             std::replace(replace_name.begin(), replace_name.end(), '/', '_');
+            std::replace(replace_name.begin(), replace_name.end(), ':', '_');
             const auto dump_data_path = model_checker_params_.dump_dir_path + replace_name + ".txt";
 
             FileReader file_reader;


### PR DESCRIPTION
修复当模型转换启用--align参数时，因为blob name符号":"未统一转换成"_"，导致model check结果异常的bug。
```
model check failed! (error: code: 0x6000 msg: extend failed: mat map is not match with blobs map)
```
PS：model_check这目录代码够乱的，像赶feature搞出来的，这框架还能商用么？