### PR TITLE
修复 Reformat 单测不通过

### DIFF
--- a/source/tnn/core/default_network.cc
+++ b/source/tnn/core/default_network.cc
@@ -190,8 +190,8 @@ Status DefaultNetwork::InitLayers(NetStructure *net_structure, NetResource *net_
             auto blob = blob_manager_->GetBlob(name);
             // skip const blobs
             if (const_blobs.count(name) == 0) {
-                auto ret  = UpdateBlobPrecision(layer_info, true, is_quantized_net, name, net_resource, &blob);
                 input_fmt = blob->GetBlobDesc().data_format;
+                auto ret  = UpdateBlobPrecision(layer_info, true, is_quantized_net, name, net_resource, &blob);
                 RETURN_ON_NEQ(ret, TNN_OK);
             }
         }
@@ -334,9 +334,6 @@ Status DefaultNetwork::AllocateBlobMemory() {
 Status DefaultNetwork::GenerateInt8Blob(const std::string &name, NetResource *net_resource, Blob **blob) {
     auto new_blob = new BlobInt8((*blob)->GetBlobDesc(), (*blob)->GetHandle());
     CHECK_PARAM_NULL(new_blob);
-    if (device_->GetDeviceType() == DEVICE_ARM) {
-        new_blob->GetBlobDesc().data_format = DATA_FORMAT_NHWC4;
-    }
 
     std::string blob_scale_name = name + "_scale_data_";
 #ifdef GENERATE_RESOURCE

--- a/source/tnn/device/arm/acc/arm_reformat_layer_acc.cc
+++ b/source/tnn/device/arm/acc/arm_reformat_layer_acc.cc
@@ -35,6 +35,10 @@ Status ArmReformatLayerAcc::Init(Context *context, LayerParam *param, LayerResou
             reformat_param->type = NC4HW4FP32_2_NC8HW8FP16;
         } else if (reformat_param->src_type == DATA_TYPE_HALF && reformat_param->dst_type == DATA_TYPE_FLOAT) {
             reformat_param->type = NC8HW8FP16_2_NC4HW4FP32;
+        } else if (reformat_param->src_type == DATA_TYPE_INT8 && reformat_param->dst_type == DATA_TYPE_FLOAT) {
+            reformat_param->type = DEQUANT_ONLY;
+        } else if (reformat_param->src_type == DATA_TYPE_FLOAT && reformat_param->dst_type == DATA_TYPE_INT8) {
+            reformat_param->type = QUANT_ONLY;
         } else {
             if (reformat_param->src_type == DATA_TYPE_BFP16 || reformat_param->dst_type == DATA_TYPE_BFP16) {
                 LOGE("unsupport precision mode, please dont use precision = low for int8");

--- a/source/tnn/interpreter/net_structure.cc
+++ b/source/tnn/interpreter/net_structure.cc
@@ -53,4 +53,14 @@ bool NeedDoConstantFolding(NetStructure* net_struct) {
     return false;
 }
 
+bool IsQuantizedLayerFromInputName(NetStructure* net_structure, const std::string& input_name) {
+    for (const auto& layer_info : net_structure->layers) {
+        const auto& inputs = layer_info->inputs;
+        if (std::find(inputs.begin(), inputs.end(), input_name) != inputs.end()) {
+            return layer_info->param->quantized;
+        }
+    }
+    return false;
+}
+
 }  // namespace TNN_NS

--- a/source/tnn/interpreter/net_structure.h
+++ b/source/tnn/interpreter/net_structure.h
@@ -108,6 +108,8 @@ std::shared_ptr<LayerInfo> GetLayerInfoFromName(NetStructure* net_struct, std::s
 bool GetQuantizedInfoFromNetStructure(NetStructure* net_struct);
 
 bool NeedDoConstantFolding(NetStructure* net_struct);
+
+bool IsQuantizedLayerFromInputName(NetStructure* net_structure, const std::string& input_name);
 }  // namespace TNN_NS
 
 #endif  // TNN_SOURCE_TNN_INTERPRETER_NET_STRUCTURE_H_


### PR DESCRIPTION
1. 修复 reformat 单元测试不通过， #1298 
2. 调整了针对 量化模型设置 data format 的逻辑。