### PR TITLE
修复了自动化构建 docker image 时编译失败的 bug

### DIFF
--- a/tools/convert2tnn/build.sh
+++ b/tools/convert2tnn/build.sh
@@ -40,7 +40,7 @@ function build_model_check_and_tnn_converter_and_onnx2tnn() {
         -DTNN_ONNX2TNN_ENABLE:BOOL="ON" \
         -DTNN_BUILD_SHARED="OFF"
 
-    make -j8
+    make -j4
 
     if [ -f "model_check" ]; then
         cp model_check ../${BIN_DIR}/


### PR DESCRIPTION
1. fix issue #1313 
2. 由于构建机的性能比较差，当编译的线程数比较多时，容易出现内存不足，进而导致编译失败。解决办法是减少编译的线程数。