### PR TITLE
[CUDA] add param check before init

### DIFF
--- a/source/tnn/device/cuda/acc/cuda_conv_layer_acc.cu
+++ b/source/tnn/device/cuda/acc/cuda_conv_layer_acc.cu
@@ -36,6 +36,10 @@ Status CudaConvLayerAcc::Init(Context *context, LayerParam *param, LayerResource
     DimsVector input_dims  = inputs[0]->GetBlobDesc().dims;
     DimsVector output_dims = outputs[0]->GetBlobDesc().dims;
 
+    if (input_dims.size() == 0 || output_dims.size() == 0) {
+        return TNNERR_LAYER_ERR;
+    }
+
     Blob *input = inputs[0];
 
     ConvLayerParam *conv_param = dynamic_cast<ConvLayerParam *>(param);


### PR DESCRIPTION
当cuda layer在trtnetwork中作为plugin被调用时，在constfolder之前可能没有dims信息，直接使用dims会有crash，目前trtnetwork的逻辑初次初始化失败后，才会调用constfolder逻辑