### PR TITLE
Tnn torch subgraph debug

### DIFF
--- a/source/tnn/core/layer_type.cc
+++ b/source/tnn/core/layer_type.cc
@@ -252,6 +252,7 @@ static std::map<std::string, LayerType> global_layer_type_map = {
     {"CbamFusedPooling", LAYER_CBAM_FUSED_POOLING},
     {"Softsign", LAYER_SOFTSIGN},
     {"LogSoftmax", LAYER_LOGSOFTMAX},
+    {"SplitTorch", LAYER_SPLITTORCH},
     {"QuantizedReshape", LAYER_RESHAPE},
     {"QuantizedPermute", LAYER_PERMUTE}
 };

--- a/source/tnn/core/layer_type.cc
+++ b/source/tnn/core/layer_type.cc
@@ -253,6 +253,7 @@ static std::map<std::string, LayerType> global_layer_type_map = {
     {"Softsign", LAYER_SOFTSIGN},
     {"LogSoftmax", LAYER_LOGSOFTMAX},
     {"SplitTorch", LAYER_SPLITTORCH},
+    {"PermuteV2", LAYER_PERMUTEV2},
     {"QuantizedReshape", LAYER_RESHAPE},
     {"QuantizedPermute", LAYER_PERMUTE}
 };

--- a/source/tnn/core/layer_type.h
+++ b/source/tnn/core/layer_type.h
@@ -225,6 +225,7 @@ enum LayerType {
     LAYER_LESS                                              = 334,
     LAYER_NON_MAX_SUPPRESSION                               = 335,
     LAYER_SCATTER                                           = 336,
+    LAYER_SPLITTORCH                                        = 337,
 
     LAYER_BLOB_SCALE                                        = 600,
 

--- a/source/tnn/core/layer_type.h
+++ b/source/tnn/core/layer_type.h
@@ -226,6 +226,7 @@ enum LayerType {
     LAYER_NON_MAX_SUPPRESSION                               = 335,
     LAYER_SCATTER                                           = 336,
     LAYER_SPLITTORCH                                        = 337,
+    LAYER_PERMUTEV2                                         = 338,
 
     LAYER_BLOB_SCALE                                        = 600,
 

--- a/source/tnn/device/cpu/acc/cpu_permute_layer_acc.cc
+++ b/source/tnn/device/cpu/acc/cpu_permute_layer_acc.cc
@@ -69,5 +69,6 @@ Status CpuPermuteLayerAcc::Forward(const std::vector<Blob *> &inputs, const std:
 }
 
 CpuTypeLayerAccRegister<TypeLayerAccCreator<CpuPermuteLayerAcc>> g_cpu_permute_layer_acc_register(LAYER_PERMUTE);
+CpuTypeLayerAccRegister<TypeLayerAccCreator<CpuPermuteLayerAcc>> g_cpu_permutev2_layer_acc_register(LAYER_PERMUTEV2);
 
 }  // namespace TNN_NS

--- a/source/tnn/device/cpu/acc/cpu_splitv_layer_acc.cc
+++ b/source/tnn/device/cpu/acc/cpu_splitv_layer_acc.cc
@@ -84,5 +84,6 @@ Status CpuSplitVLayerAcc::Forward(const std::vector<Blob *> &inputs, const std::
 }
 
 REGISTER_CPU_ACC(SplitV, LAYER_SPLITV);
+REGISTER_CPU_ACC(SplitV, LAYER_SPLITTORCH);
 
 }  // namespace TNN_NS

--- a/source/tnn/device/cuda/acc/cuda_permute_layer_acc.cu
+++ b/source/tnn/device/cuda/acc/cuda_permute_layer_acc.cu
@@ -33,5 +33,6 @@ Status CudaPermuteLayerAcc::Forward(const std::vector<Blob *> &inputs, const std
 }
 
 REGISTER_CUDA_ACC(Permute, LAYER_PERMUTE);
+REGISTER_CUDA_ACC(Permute, LAYER_PERMUTEV2);
 
 }  // namespace TNN_NS

--- a/source/tnn/device/cuda/acc/cuda_splitv_layer_acc.cu
+++ b/source/tnn/device/cuda/acc/cuda_splitv_layer_acc.cu
@@ -93,5 +93,6 @@ Status CudaSplitVLayerAcc::Forward(const std::vector<Blob *> &inputs, const std:
 }
 
 REGISTER_CUDA_ACC(SplitV, LAYER_SPLITV);
+REGISTER_CUDA_ACC(SplitV, LAYER_SPLITTORCH);
 
 }  // namespace TNN_NS

--- a/source/tnn/device/x86/acc/x86_permute_layer_acc.cc
+++ b/source/tnn/device/x86/acc/x86_permute_layer_acc.cc
@@ -143,5 +143,6 @@ Status X86PermuteLayerAcc::DoForward(const std::vector<Blob *> &inputs, const st
 }
 
 X86TypeLayerAccRegister<TypeLayerAccCreator<X86PermuteLayerAcc>> g_x86_permute_layer_acc_register(LAYER_PERMUTE);
+X86TypeLayerAccRegister<TypeLayerAccCreator<X86PermuteLayerAcc>> g_x86_permutev2_layer_acc_register(LAYER_PERMUTEV2);
 
 }  // namespace TNN_NS

--- a/source/tnn/device/x86/acc/x86_splitv_layer_acc.cc
+++ b/source/tnn/device/x86/acc/x86_splitv_layer_acc.cc
@@ -61,5 +61,6 @@ Status X86SplitVLayerAcc::DoForward(const std::vector<Blob *> &inputs, const std
 }
 
 REGISTER_X86_ACC(SplitV, LAYER_SPLITV);
+REGISTER_X86_ACC(SplitV, LAYER_SPLITTORCH);
 
 }  // namespace TNN_NS

--- a/source/tnn/interpreter/layer_param.h
+++ b/source/tnn/interpreter/layer_param.h
@@ -249,6 +249,13 @@ struct PermuteLayerParam : public LayerParam {
     PARAM_COPY(PermuteLayerParam)
 };
 
+struct PermuteV2LayerParam : public PermuteLayerParam {
+    int dim0 = 0;
+    int dim1 = 0;
+
+    PARAM_COPY(PermuteV2LayerParam)
+};
+
 struct CastLayerParam : public LayerParam {
     int to   = 0;
     int from = 0;  // used for HUAWEI_NPU

--- a/source/tnn/interpreter/layer_param.h
+++ b/source/tnn/interpreter/layer_param.h
@@ -691,6 +691,12 @@ struct LogSoftmaxLayerParam : public LayerParam {
     PARAM_COPY(LogSoftmaxLayerParam)
 };
 
+struct SplitTorchLayerParam : public SplitVLayerParam {
+    int split_size          = 0;
+
+    PARAM_COPY(SplitTorchLayerParam)
+};
+
 };  // namespace TNN_NS
 
 #endif  // TNN_SOURCE_TNN_INTERPRETER_LAYER_PARAM_H

--- a/source/tnn/interpreter/tnn/layer_interpreter/permutev2_layer_interpreter.cc
+++ b/source/tnn/interpreter/tnn/layer_interpreter/permutev2_layer_interpreter.cc
@@ -1,0 +1,70 @@
+// Tencent is pleased to support the open source community by making TNN available.
+//
+// Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "tnn/interpreter/tnn/layer_interpreter/abstract_layer_interpreter.h"
+
+#include <stdlib.h>
+
+namespace TNN_NS {
+
+DECLARE_LAYER_INTERPRETER(PermuteV2, LAYER_PERMUTEV2);
+
+Status PermuteV2LayerInterpreter::InterpretProto(str_arr layer_cfg_arr, int start_index, LayerParam** param) {
+    auto layer_param = new PermuteV2LayerParam();
+    *param           = layer_param;
+    int index        = start_index;
+
+    // int order_size;
+    // order_size = atoi(layer_cfg_arr[index++].c_str());
+
+    layer_param->orders.clear();
+    // for (int i = 0; i < order_size; i++) {
+    //     int v = atoi(layer_cfg_arr[index++].c_str());
+    //     // v should be less than the input dimension.
+    //     ASSERT(v < order_size);
+    //     layer_param->orders.push_back(v);
+    // }
+    layer_param->dim0 = atoi(layer_cfg_arr[index++].c_str());
+    layer_param->dim1 = atoi(layer_cfg_arr[index++].c_str());
+
+    return TNN_OK;
+}
+
+Status PermuteV2LayerInterpreter::InterpretResource(Deserializer& deserializer, LayerResource** resource) {
+    return TNN_OK;
+}
+
+Status PermuteV2LayerInterpreter::SaveProto(std::ostream& output_stream, LayerParam* param) {
+    PermuteV2LayerParam* layer_param = dynamic_cast<PermuteV2LayerParam*>(param);
+    if (nullptr == layer_param) {
+        LOGE("invalid layer param to save\n");
+        return Status(TNNERR_NULL_PARAM, "invalid layer param to save");
+    }
+
+    // output_stream << layer_param->orders.size() << " ";
+    // for (auto item : layer_param->orders)
+    //     output_stream << item << " ";
+    output_stream << layer_param->dim0 << " ";
+    output_stream << layer_param->dim0 << " ";
+
+    return TNN_OK;
+}
+
+Status PermuteV2LayerInterpreter::SaveResource(Serializer& serializer, LayerParam* param, LayerResource* resource) {
+    return TNN_OK;
+}
+
+REGISTER_LAYER_INTERPRETER(PermuteV2, LAYER_PERMUTEV2);
+
+}  // namespace TNN_NS

--- a/source/tnn/interpreter/tnn/layer_interpreter/split_torch_layer_interpreter.cc
+++ b/source/tnn/interpreter/tnn/layer_interpreter/split_torch_layer_interpreter.cc
@@ -1,0 +1,60 @@
+// Tencent is pleased to support the open source community by making TNN available.
+//
+// Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include "tnn/interpreter/tnn/layer_interpreter/abstract_layer_interpreter.h"
+
+#include <stdlib.h>
+
+namespace TNN_NS {
+
+    DECLARE_LAYER_INTERPRETER(SplitTorch, LAYER_SPLITTORCH);
+
+    Status SplitTorchLayerInterpreter::InterpretProto(str_arr layer_cfg_arr, int index, LayerParam** param) {
+        auto p = CreateLayerParam<SplitTorchLayerParam>(param);
+
+        int slice_count = 0;
+        GET_INT_2(p->axis, slice_count);
+
+        p->slices.clear();
+        GET_INT_N_INTO_VEC(p->slices, slice_count);
+
+        GET_INT_1(p->split_size);
+
+        return TNN_OK;
+    }
+
+    Status SplitTorchLayerInterpreter::InterpretResource(Deserializer& deserializer, LayerResource** resource) {
+        return TNN_OK;
+    }
+
+    Status SplitTorchLayerInterpreter::SaveProto(std::ostream& output_stream, LayerParam* param) {
+        CAST_OR_RET_ERROR(split_torch_param, SplitTorchLayerParam, "invalid layer param to save", param);
+
+        output_stream << split_torch_param->axis << " ";
+        output_stream << split_torch_param->slices.size() << " ";
+        for (auto item : split_torch_param->slices) {
+            output_stream << item << " ";
+        }
+        output_stream << split_torch_param->split_size << " ";
+
+        return TNN_OK;
+    }
+
+    Status SplitTorchLayerInterpreter::SaveResource(Serializer& serializer, LayerParam* param, LayerResource* resource) {
+        return TNN_OK;
+    }
+
+    REGISTER_LAYER_INTERPRETER(SplitTorch, LAYER_SPLITTORCH);
+
+}  // namespace TNN_NS

--- a/source/tnn/layer/permutev2_layer.cc
+++ b/source/tnn/layer/permutev2_layer.cc
@@ -1,0 +1,76 @@
+// Tencent is pleased to support the open source community by making TNN available.
+//
+// Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+
+#include "tnn/layer/base_layer.h"
+
+namespace TNN_NS {
+
+class PermuteLayer;
+DECLARE_LAYER(PermuteV2, LAYER_PERMUTEV2);
+
+Status PermuteV2Layer::InferOutputDataType() {
+    return BaseLayer::InferOutputDataType();
+}
+
+Status PermuteV2Layer::InferOutputShape(bool ignore_error) {
+    BaseLayer::InferOutputShape(ignore_error);
+    
+    auto permute_param = dynamic_cast<PermuteV2LayerParam*>(param_);
+    CHECK_PARAM_NULL(permute_param);
+
+    auto input_blob  = input_blobs_[0];
+    auto output_blob = output_blobs_[0];
+
+    DimsVector output_dims;
+
+    auto input_dims = input_blob->GetBlobDesc().dims;
+    std::vector<int> orders(input_dims.size());
+    std::iota(orders.begin(), orders.end(), 0);
+    if (permute_param->dim0 < 0) permute_param->dim0 += input_dims.size();
+    if (permute_param->dim1 < 0) permute_param->dim1 += input_dims.size();
+    std::swap(orders[permute_param->dim0], orders[permute_param->dim1]);
+
+    permute_param->orders = orders;
+
+    for (int i = 0; i < input_dims.size(); ++i) {
+        if (std::find(orders.begin(), orders.end(), i) == orders.end()) {
+            orders.push_back(i);
+        }
+    }
+    if (permute_param->orders.size() != input_dims.size()) {
+        LOGE_IF(!ignore_error, "Permute param got wrong size.\n");
+        return Status(TNNERR_PARAM_ERR, "Permute param got wrong size");
+    }
+
+    for (int i = 0; i < permute_param->orders.size(); ++i) {
+        int order = permute_param->orders[i];
+        if (order < 0 || order > input_dims.size() - 1) {
+            LOGE_IF(!ignore_error, "Permute param out of range.\n");
+            return Status(TNNERR_PARAM_ERR, "Permute param out of range");
+        }
+        output_dims.push_back(input_dims[order]);
+    }
+    
+    output_blob->GetBlobDesc().dims = output_dims;
+
+    return TNN_OK;
+}
+
+REGISTER_LAYER(PermuteV2, LAYER_PERMUTEV2);
+
+}  // namespace TNN_NS

--- a/source/tnn/layer/split_torch_layer.cc
+++ b/source/tnn/layer/split_torch_layer.cc
@@ -18,66 +18,66 @@
 
 namespace TNN_NS {
 
-    DECLARE_LAYER(SplitTorch, LAYER_SPLITTORCH);
+DECLARE_LAYER(SplitTorch, LAYER_SPLITTORCH);
 
-    Status SplitTorchLayer::InferOutputDataType() {
-        return BaseLayer::InferOutputDataType();
+Status SplitTorchLayer::InferOutputDataType() {
+    return BaseLayer::InferOutputDataType();
+}
+
+Status SplitTorchLayer::InferOutputShape(bool ignore_error) {
+    BaseLayer::InferOutputShape(ignore_error);
+
+    auto layer_param = dynamic_cast<SplitTorchLayerParam*>(param_);
+    if (!layer_param) {
+        return Status(TNNERR_PARAM_ERR, "SplitTorchLayer do not have valid param, please check node: " + layer_name_);
+    }
+    Blob* input_blob     = input_blobs_[0];
+    auto input_dims      = input_blob->GetBlobDesc().dims;
+    const int split_size = layer_param->split_size;
+
+    if (layer_param->axis < 0) {
+        layer_param->axis += input_dims.size();
     }
 
-    Status SplitTorchLayer::InferOutputShape(bool ignore_error) {
-        BaseLayer::InferOutputShape(ignore_error);
-
-        auto layer_param = dynamic_cast<SplitTorchLayerParam*>(param_);
-        if (!layer_param) {
-            return Status(TNNERR_PARAM_ERR, "SplitTorchLayer do not have valid param, please check node: " + layer_name_);
-        }
-        Blob* input_blob = input_blobs_[0];
-        auto input_dims  = input_blob->GetBlobDesc().dims;
-        const int split_size = layer_param->split_size;
-
-        if (layer_param->axis < 0) {
-            layer_param->axis += input_dims.size();
-        }
-
-        if (split_size == 0) {
-            return Status(TNNERR_PARAM_ERR, "SplitTorchLayer has invalid param, split size is zero");
-        }
-
-        const int input_size = input_dims[layer_param->axis];
-        const int num_split = input_size / split_size;
-        const int last_size = input_size % split_size;
-
-        std::vector<int> slices(num_split, split_size);
-        if (last_size > 0) {
-            slices.push_back(last_size);
-        }
-
-        layer_param->slices = slices;
-
-        if (layer_param->slices.size() != output_blobs_.size()) {
-            const int obs = output_blobs_.size();
-            int x = 0;
-            return Status(TNNERR_PARAM_ERR, "SplitTorchLayer has invalid param, slices size != output blobs size ");
-        }
-
-        int size_sum = layer_param->slices[0];
-        for (int i = 1; i < layer_param->slices.size(); i++) {
-            size_sum += layer_param->slices[i];
-        }
-
-        if (size_sum != input_dims[layer_param->axis]) {
-            return Status(TNNERR_PARAM_ERR, "SplitTorchLayer has invalid slices");
-        }
-
-        for (size_t i = 0; i < output_blobs_.size(); i++) {
-            auto output_dims                     = input_dims;
-            output_dims[layer_param->axis]       = layer_param->slices[i];
-            output_blobs_[i]->GetBlobDesc().dims = output_dims;
-        }
-
-        return TNN_OK;
+    if (split_size == 0) {
+        return Status(TNNERR_PARAM_ERR, "SplitTorchLayer has invalid param, split size is zero");
     }
 
-    REGISTER_LAYER(SplitTorch, LAYER_SPLITTORCH);
+    const int input_size = input_dims[layer_param->axis];
+    const int num_split  = input_size / split_size;
+    const int last_size  = input_size % split_size;
+
+    std::vector<int> slices(num_split, split_size);
+    if (last_size > 0) {
+        slices.push_back(last_size);
+    }
+
+    layer_param->slices = slices;
+
+    if (layer_param->slices.size() != output_blobs_.size()) {
+        const int obs = output_blobs_.size();
+        int x         = 0;
+        return Status(TNNERR_PARAM_ERR, "SplitTorchLayer has invalid param, slices size != output blobs size ");
+    }
+
+    int size_sum = layer_param->slices[0];
+    for (int i = 1; i < layer_param->slices.size(); i++) {
+        size_sum += layer_param->slices[i];
+    }
+
+    if (size_sum != input_dims[layer_param->axis]) {
+        return Status(TNNERR_PARAM_ERR, "SplitTorchLayer has invalid slices");
+    }
+
+    for (size_t i = 0; i < output_blobs_.size(); i++) {
+        auto output_dims                     = input_dims;
+        output_dims[layer_param->axis]       = layer_param->slices[i];
+        output_blobs_[i]->GetBlobDesc().dims = output_dims;
+    }
+
+    return TNN_OK;
+}
+
+REGISTER_LAYER(SplitTorch, LAYER_SPLITTORCH);
 
 }  // namespace TNN_NS

--- a/source/tnn/layer/split_torch_layer.cc
+++ b/source/tnn/layer/split_torch_layer.cc
@@ -1,0 +1,83 @@
+// Tencent is pleased to support the open source community by making TNN available.
+//
+// Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#include <cmath>
+
+#include "tnn/layer/base_layer.h"
+
+namespace TNN_NS {
+
+    DECLARE_LAYER(SplitTorch, LAYER_SPLITTORCH);
+
+    Status SplitTorchLayer::InferOutputDataType() {
+        return BaseLayer::InferOutputDataType();
+    }
+
+    Status SplitTorchLayer::InferOutputShape(bool ignore_error) {
+        BaseLayer::InferOutputShape(ignore_error);
+
+        auto layer_param = dynamic_cast<SplitTorchLayerParam*>(param_);
+        if (!layer_param) {
+            return Status(TNNERR_PARAM_ERR, "SplitTorchLayer do not have valid param, please check node: " + layer_name_);
+        }
+        Blob* input_blob = input_blobs_[0];
+        auto input_dims  = input_blob->GetBlobDesc().dims;
+        const int split_size = layer_param->split_size;
+
+        if (layer_param->axis < 0) {
+            layer_param->axis += input_dims.size();
+        }
+
+        if (split_size == 0) {
+            return Status(TNNERR_PARAM_ERR, "SplitTorchLayer has invalid param, split size is zero");
+        }
+
+        const int input_size = input_dims[layer_param->axis];
+        const int num_split = input_size / split_size;
+        const int last_size = input_size % split_size;
+
+        std::vector<int> slices(num_split, split_size);
+        if (last_size > 0) {
+            slices.push_back(last_size);
+        }
+
+        layer_param->slices = slices;
+
+        if (layer_param->slices.size() != output_blobs_.size()) {
+            const int obs = output_blobs_.size();
+            int x = 0;
+            return Status(TNNERR_PARAM_ERR, "SplitTorchLayer has invalid param, slices size != output blobs size ");
+        }
+
+        int size_sum = layer_param->slices[0];
+        for (int i = 1; i < layer_param->slices.size(); i++) {
+            size_sum += layer_param->slices[i];
+        }
+
+        if (size_sum != input_dims[layer_param->axis]) {
+            return Status(TNNERR_PARAM_ERR, "SplitTorchLayer has invalid slices");
+        }
+
+        for (size_t i = 0; i < output_blobs_.size(); i++) {
+            auto output_dims                     = input_dims;
+            output_dims[layer_param->axis]       = layer_param->slices[i];
+            output_blobs_[i]->GetBlobDesc().dims = output_dims;
+        }
+
+        return TNN_OK;
+    }
+
+    REGISTER_LAYER(SplitTorch, LAYER_SPLITTORCH);
+
+}  // namespace TNN_NS

--- a/source/tnn/network/tensorrt/layer_builder/permute_layer_builder.cc
+++ b/source/tnn/network/tensorrt/layer_builder/permute_layer_builder.cc
@@ -44,6 +44,7 @@ ILayer* PermuteTRTLayerBuilder::AddToNetwork(INetworkDefinition* network) {
 }
 
 REGISTER_TENSORRT_LAYER_BUILDER(Permute, LAYER_PERMUTE);
+REGISTER_TENSORRT_LAYER_BUILDER(Permute, LAYER_PERMUTEV2);
 
 }  //  namespace TNN_NS
 

--- a/source/tnn/network/tensorrt/layer_builder/splitv_layer_builder.cc
+++ b/source/tnn/network/tensorrt/layer_builder/splitv_layer_builder.cc
@@ -59,5 +59,6 @@ const char* SplitVPluginCreator::getPluginName() const noexcept {
 }
 
 REGISTER_TENSORRT_PLUGIN_LAYER_BUILDER(SplitV, LAYER_SPLITV);
+REGISTER_TENSORRT_PLUGIN_LAYER_BUILDER(SplitV, LAYER_SPLITTORCH);
 
 }  //  namespace TNN_NS

--- a/source/tnn/network/torch/partitioning.cc
+++ b/source/tnn/network/torch/partitioning.cc
@@ -366,7 +366,7 @@ std::vector<SegmentedBlock> Partition(torch::jit::Module& mod, std::shared_ptr<t
     std::vector<SegmentedBlock> segmented_blocks = segment_graph(g);
 
     // resolve nonTensor inputs/outputs
-    resolveNonTensorInputs(segmented_blocks, g);
+    // resolveNonTensorInputs(segmented_blocks, g);
 
     // register input/output torch::jit::Value for segmented graphs
     registerSegmentsOutputs(segmented_blocks, g);

--- a/source/tnn/network/torch/partitioning.cc
+++ b/source/tnn/network/torch/partitioning.cc
@@ -372,20 +372,31 @@ std::vector<SegmentedBlock> Partition(torch::jit::Module& mod, std::shared_ptr<t
     registerSegmentsOutputs(segmented_blocks, g);
 
     // only return TNN subgraph
+    
+     for (auto block : segmented_blocks) {
+         printf("====================== subgraph start %d ======================\n", block.target());
+         // if (block.target() == SegmentedBlock::kTNN) {
+         if (1) {
+             std::cout << block.g()->toString(false);
+         }
+         printf("====================== subgraph end   %d ======================\n", block.target());
+     }
+
     segmented_blocks.erase(
         std::remove_if(segmented_blocks.begin(), segmented_blocks.end(),
                        [](SegmentedBlock& seg_block) { return seg_block.target() == SegmentedBlock::kTorch; }),
         segmented_blocks.end());
 
-    // for (auto block : segmented_blocks) {
-    //     printf("====================== subgraph start %d ======================\n", block.target());
-    //     // if (block.target() == SegmentedBlock::kTNN) {
-    //     if (1) {
-    //         std::cout << block.g()->toString(false);
-    //     }
-    //     printf("====================== subgraph end   %d ======================\n", block.target());
-    // }
-
+    /*
+     for (auto block : segmented_blocks) {
+         printf("====================== subgraph start %d ======================\n", block.target());
+         // if (block.target() == SegmentedBlock::kTNN) {
+         if (1) {
+             std::cout << block.g()->toString(false);
+         }
+         printf("====================== subgraph end   %d ======================\n", block.target());
+     }
+*/
     return segmented_blocks;
 }
 

--- a/source/tnn/network/torch/partitioning.cc
+++ b/source/tnn/network/torch/partitioning.cc
@@ -321,6 +321,7 @@ std::vector<SegmentedBlock> segment_graph(std::shared_ptr<torch::jit::Graph> g) 
 
         // This code is a special support for YOLO V5 and needs to be optimized in the future.
         auto check_list_construct = [](torch::jit::Node* node) -> bool {
+            return false;
             if (node->kind() != at::prim::ListConstruct) {
                 return false;
             }
@@ -365,38 +366,40 @@ std::vector<SegmentedBlock> Partition(torch::jit::Module& mod, std::shared_ptr<t
     // segment lowering global graph into blocks
     std::vector<SegmentedBlock> segmented_blocks = segment_graph(g);
 
+    auto print_seg_nodes = [&](std::string msg) {
+        std::cout << "+++++++++++++++++++ " << msg << " +++++++++++++++++++" << std::endl;
+        for (auto block : segmented_blocks) {
+            std::cout << block.g()->toString(false);
+            for (auto node : block.raw_nodes()) {
+                std::cout << node->kind().toQualString() << std::endl;
+            }
+            std::cout << "++++++++++++++++++++++++ " << block.target() << " +++++++++++++++++++++++++" << std::endl;
+        }
+    };
+    print_seg_nodes("after seg");
     // resolve nonTensor inputs/outputs
-    // resolveNonTensorInputs(segmented_blocks, g);
+    resolveNonTensorInputs(segmented_blocks, g);
+    print_seg_nodes("after resolve");
 
     // register input/output torch::jit::Value for segmented graphs
     registerSegmentsOutputs(segmented_blocks, g);
+    print_seg_nodes("after register");
 
     // only return TNN subgraph
-    
-     for (auto block : segmented_blocks) {
-         printf("====================== subgraph start %d ======================\n", block.target());
-         // if (block.target() == SegmentedBlock::kTNN) {
-         if (1) {
-             std::cout << block.g()->toString(false);
-         }
-         printf("====================== subgraph end   %d ======================\n", block.target());
-     }
-
     segmented_blocks.erase(
         std::remove_if(segmented_blocks.begin(), segmented_blocks.end(),
                        [](SegmentedBlock& seg_block) { return seg_block.target() == SegmentedBlock::kTorch; }),
         segmented_blocks.end());
 
-    /*
-     for (auto block : segmented_blocks) {
-         printf("====================== subgraph start %d ======================\n", block.target());
-         // if (block.target() == SegmentedBlock::kTNN) {
-         if (1) {
-             std::cout << block.g()->toString(false);
-         }
-         printf("====================== subgraph end   %d ======================\n", block.target());
-     }
-*/
+    // for (auto block : segmented_blocks) {
+    //     printf("====================== subgraph start %d ======================\n", block.target());
+    //     // if (block.target() == SegmentedBlock::kTNN) {
+    //     if (1) {
+    //         std::cout << block.g()->toString(false);
+    //     }
+    //     printf("====================== subgraph end   %d ======================\n", block.target());
+    // }
+
     return segmented_blocks;
 }
 

--- a/source/tnn/network/torch/partitioning.cc
+++ b/source/tnn/network/torch/partitioning.cc
@@ -376,14 +376,14 @@ std::vector<SegmentedBlock> Partition(torch::jit::Module& mod, std::shared_ptr<t
             std::cout << "++++++++++++++++++++++++ " << block.target() << " +++++++++++++++++++++++++" << std::endl;
         }
     };
-    print_seg_nodes("after seg");
+    // print_seg_nodes("after seg");
     // resolve nonTensor inputs/outputs
     resolveNonTensorInputs(segmented_blocks, g);
-    print_seg_nodes("after resolve");
+    // print_seg_nodes("after resolve");
 
     // register input/output torch::jit::Value for segmented graphs
     registerSegmentsOutputs(segmented_blocks, g);
-    print_seg_nodes("after register");
+    // print_seg_nodes("after register");
 
     // only return TNN subgraph
     segmented_blocks.erase(

--- a/source/tnn/network/torch/torch_compile.cc
+++ b/source/tnn/network/torch/torch_compile.cc
@@ -177,7 +177,7 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
                 std::vector<DimsVector> min_shape;
                 std::vector<DimsVector> max_shape;
                 std::vector<DataType> in_type;
-		for (auto &input : block.raw_inputs()) {
+                for (auto &input : block.raw_inputs()) {
                     min_shape.push_back(subgraph_min_input_info[input_idx].dims);
                     max_shape.push_back(subgraph_max_input_info[input_idx].dims);
                     in_type.push_back(subgraph_max_input_info[input_idx].data_type);
@@ -277,8 +277,8 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
     // remove constant nodes which has been convert to tnn netresource
     torch::jit::EliminateDeadCode(g);
 
-     // std::cout << "============================= the final graph ===========================" << std::endl;
-     // std::cout << g->toString() << std::endl;
+    //  std::cout << "============================= the final graph ===========================" << std::endl;
+    //  std::cout << g->toString() << std::endl;
 
     return mod;
 }

--- a/source/tnn/network/torch/torch_compile.cc
+++ b/source/tnn/network/torch/torch_compile.cc
@@ -245,7 +245,7 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
             } catch (std::exception& e) {
                 block_stop_idx = block_idx;
                 // std::cout << "exception block " << block_stop_idx << std::endl;
-                // std::cout << e.what() << std::endl;
+                std::cout << e.what() << std::endl;
                 break;
             }
             block_idx++;

--- a/source/tnn/network/torch/torch_compile.cc
+++ b/source/tnn/network/torch/torch_compile.cc
@@ -159,6 +159,7 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
 
     try {
         auto seg_blocks = partitioning::Partition(mod, g, config);
+	std::cout << "partition is ok" << std::endl;
 
         // run shape infer and combine to blocks
         if (min_input_shape.size() && max_input_shape.size() && min_input_shape.size() == max_input_shape.size()) {
@@ -168,15 +169,17 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
             std::vector<BlobDesc> subgraph_max_input_info;
             //// input type & shape will be used for random input generation, then subgraph input info can be infered out
             // InputDataTypeMap input_type;
+
+	    std::cout << "start run shape infer" << std::endl;
             partitioning::runShapeInfer(shape_mod, shape_seg, min_input_shape, input_type, config, subgraph_min_input_info);
             partitioning::runShapeInfer(shape_mod, shape_seg, max_input_shape, input_type, config, subgraph_max_input_info);
-
+	    
             int input_idx = 0;
             for (auto &block : seg_blocks) {
                 std::vector<DimsVector> min_shape;
                 std::vector<DimsVector> max_shape;
                 std::vector<DataType> in_type;
-                for (auto &input : block.raw_inputs()) {
+		for (auto &input : block.raw_inputs()) {
                     min_shape.push_back(subgraph_min_input_info[input_idx].dims);
                     max_shape.push_back(subgraph_max_input_info[input_idx].dims);
                     in_type.push_back(subgraph_max_input_info[input_idx].data_type);
@@ -205,7 +208,8 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
             return;
         }
     #endif
-
+	
+	std::cout << "start seg_blocks" << std::endl;
         int block_idx = 0;
         int block_stop_idx = INT_MAX;
         for (auto &block : seg_blocks) {
@@ -246,6 +250,7 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
             }
             block_idx++;
         }
+	std::cout << "seg block is end" << std::endl;
 
         block_idx = 0;
         for (auto &block : seg_blocks) {
@@ -269,8 +274,8 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
     // remove constant nodes which has been convert to tnn netresource
     torch::jit::EliminateDeadCode(g);
 
-    // std::cout << "============================= the final graph ===========================" << std::endl;
-    // std::cout << g->toString() << std::endl;
+     std::cout << "============================= the final graph ===========================" << std::endl;
+     std::cout << g->toString() << std::endl;
 
     return mod;
 }

--- a/source/tnn/network/torch/torch_compile.cc
+++ b/source/tnn/network/torch/torch_compile.cc
@@ -149,7 +149,7 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
 
     // std::cout << c10::toString(mod.get_method("forward").function().getSchema()) << std::endl;
     auto g = mod.get_method(forward_func_name).graph();
-    std::cout << g->toString(false) << std::endl;
+    // std::cout << g->toString(false) << std::endl;
 
     std::unordered_map<torch::jit::Value *, torch::jit::Value *> old_to_new_g;
 
@@ -159,7 +159,6 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
 
     try {
         auto seg_blocks = partitioning::Partition(mod, g, config);
-	std::cout << "partition is ok" << std::endl;
 
         // run shape infer and combine to blocks
         if (min_input_shape.size() && max_input_shape.size() && min_input_shape.size() == max_input_shape.size()) {
@@ -170,7 +169,6 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
             //// input type & shape will be used for random input generation, then subgraph input info can be infered out
             // InputDataTypeMap input_type;
 
-	    std::cout << "start run shape infer" << std::endl;
             partitioning::runShapeInfer(shape_mod, shape_seg, min_input_shape, input_type, config, subgraph_min_input_info);
             partitioning::runShapeInfer(shape_mod, shape_seg, max_input_shape, input_type, config, subgraph_max_input_info);
 	    
@@ -208,8 +206,7 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
             return;
         }
     #endif
-	
-	std::cout << "start seg_blocks" << std::endl;
+
         int block_idx = 0;
         int block_stop_idx = INT_MAX;
         for (auto &block : seg_blocks) {
@@ -250,7 +247,6 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
             }
             block_idx++;
         }
-	std::cout << "seg block is end" << std::endl;
 
         block_idx = 0;
         for (auto &block : seg_blocks) {
@@ -281,8 +277,8 @@ torch::jit::Module CompileTorch(torch::jit::Module &mod, InputShapesMap &min_inp
     // remove constant nodes which has been convert to tnn netresource
     torch::jit::EliminateDeadCode(g);
 
-     std::cout << "============================= the final graph ===========================" << std::endl;
-     std::cout << g->toString() << std::endl;
+     // std::cout << "============================= the final graph ===========================" << std::endl;
+     // std::cout << g->toString() << std::endl;
 
     return mod;
 }

--- a/source/tnn/network/torch/torch_convert.cc
+++ b/source/tnn/network/torch/torch_convert.cc
@@ -91,6 +91,13 @@ c10::intrusive_ptr<runtime::TNNEngine> ConvertBlockToInstance(partitioning::Segm
         net_structure->inputs_shape_map = max_inputs_shape_map;
         net_structure->input_data_type_map = inputs_type_map;
 
+        // static int __cnt = 0;
+        // const std::string root = "./";
+        // const std::string model_name = "splt-" + std::to_string(__cnt++);
+        // const std::string proto_path = root + model_name + ".tnnproto";
+        // const std::string model_path = root + model_name + ".tnnmodel";
+        // TNN_NS::ModelPacker model_packer(net_structure, net_resource);
+        // Status status = model_packer.Pack(proto_path, model_path);
         instance_ptr->instance_->Init(ctx->get_interpreter(), min_inputs_shape_map, max_inputs_shape_map);
         instance_ptr->is_init_ = true;
     }

--- a/source/tnn/network/torch/torch_convert.cc
+++ b/source/tnn/network/torch/torch_convert.cc
@@ -63,7 +63,7 @@ c10::intrusive_ptr<runtime::TNNEngine> ConvertBlockToInstance(partitioning::Segm
         if (kind.is_prim() && ctx->dealPrime(node)) {
             continue;
         }
-        std::cout << kind.toQualString() << std::endl;
+        // std::cout << kind.toQualString() << std::endl;
 
         ConvertNodeToLayer(node, net_structure, net_resource);
     }
@@ -90,15 +90,6 @@ c10::intrusive_ptr<runtime::TNNEngine> ConvertBlockToInstance(partitioning::Segm
         }
         net_structure->inputs_shape_map = max_inputs_shape_map;
         net_structure->input_data_type_map = inputs_type_map;
-
-        static int __cnt = 0;
-        const std::string root = "./";
-        const std::string model_name = "splt-" + std::to_string(__cnt++);
-        const std::string proto_path = root + model_name + ".tnnproto";
-        const std::string model_path = root + model_name + ".tnnmodel";
-        TNN_NS::ModelPacker model_packer(net_structure, net_resource);
-        Status status = model_packer.Pack(proto_path, model_path);
-
 
         instance_ptr->instance_->Init(ctx->get_interpreter(), min_inputs_shape_map, max_inputs_shape_map);
         instance_ptr->is_init_ = true;

--- a/source/tnn/network/torch/torch_convert.cc
+++ b/source/tnn/network/torch/torch_convert.cc
@@ -1,6 +1,9 @@
 #include "tnn/network/torch/torch_convert.h"
 #include "tnn/network/torch/torch_op_converter.h"
 #include "tnn/interpreter/tnn/model_interpreter.h"
+
+#include <tnn/interpreter/tnn/model_packer.h>
+
 namespace TNN_NS {
 namespace conversion {
 
@@ -89,6 +92,14 @@ c10::intrusive_ptr<runtime::TNNEngine> ConvertBlockToInstance(partitioning::Segm
         instance_ptr->instance_->Init(ctx->get_interpreter(), min_inputs_shape_map, max_inputs_shape_map);
         instance_ptr->is_init_ = true;
     }
+
+    static int __cnt = 0;
+    const std::string root = "/home/ealinli/workspace/model/splt_at_conv/debug/";
+    const std::string model_name = "splt-" + std::to_string(__cnt++);
+    const std::string proto_path = root + model_name + ".tnnproto";
+    const std::string model_path = root + model_name + ".tnnmodel";
+    TNN_NS::ModelPacker model_packer(net_structure, net_resource);
+    Status status = model_packer.Pack(proto_path, model_path);
 
     return instance_ptr;
 }

--- a/source/tnn/network/torch/torch_convert.cc
+++ b/source/tnn/network/torch/torch_convert.cc
@@ -63,6 +63,7 @@ c10::intrusive_ptr<runtime::TNNEngine> ConvertBlockToInstance(partitioning::Segm
         if (kind.is_prim() && ctx->dealPrime(node)) {
             continue;
         }
+        std::cout << kind.toQualString() << std::endl;
 
         ConvertNodeToLayer(node, net_structure, net_resource);
     }
@@ -89,17 +90,19 @@ c10::intrusive_ptr<runtime::TNNEngine> ConvertBlockToInstance(partitioning::Segm
         }
         net_structure->inputs_shape_map = max_inputs_shape_map;
         net_structure->input_data_type_map = inputs_type_map;
+
+        static int __cnt = 0;
+        const std::string root = "./";
+        const std::string model_name = "splt-" + std::to_string(__cnt++);
+        const std::string proto_path = root + model_name + ".tnnproto";
+        const std::string model_path = root + model_name + ".tnnmodel";
+        TNN_NS::ModelPacker model_packer(net_structure, net_resource);
+        Status status = model_packer.Pack(proto_path, model_path);
+
+
         instance_ptr->instance_->Init(ctx->get_interpreter(), min_inputs_shape_map, max_inputs_shape_map);
         instance_ptr->is_init_ = true;
     }
-
-    static int __cnt = 0;
-    const std::string root = "/home/ealinli/workspace/model/splt_at_conv/debug/";
-    const std::string model_name = "splt-" + std::to_string(__cnt++);
-    const std::string proto_path = root + model_name + ".tnnproto";
-    const std::string model_path = root + model_name + ".tnnmodel";
-    TNN_NS::ModelPacker model_packer(net_structure, net_resource);
-    Status status = model_packer.Pack(proto_path, model_path);
 
     return instance_ptr;
 }

--- a/source/tnn/network/torch/torch_op_converter.cc
+++ b/source/tnn/network/torch/torch_op_converter.cc
@@ -1172,7 +1172,7 @@ public:
                 auto const_buf = getValue(input);
                 if (const_buf.GetBytesSize() > 0) {
                     if (*(const_buf.force_to<int *>()) != INT_MAX) {
-                        std::cout << input->debugName() << std::endl;
+                        const_buf.SetBufferDims({1});
                         net_resource->constant_map[input->debugName()] = std::make_shared<RawBuffer>(const_buf);
                     }
                 }

--- a/source/tnn/network/torch/torch_op_converter.cc
+++ b/source/tnn/network/torch/torch_op_converter.cc
@@ -1072,6 +1072,40 @@ public:
     }
 };
 
+// func: view(Tensor(a) self, int[] size) -> Tensor(a)
+class ReshapeTorchConverter : public TorchOpConverter {
+public:
+    Status Convert(const torch::jit::Node *node, NetStructure *net_structure, NetResource *net_resource) {
+	std::cout << "enter reshape" << std::endl;
+	std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
+        layer_info->type = LAYER_RESHAPE;
+        layer_info->type_str = "Reshape";
+        layer_info->name = node->output(0)->debugName();
+
+        for (const auto& input : node->inputs()) {
+            layer_info->inputs.push_back(input->debugName());
+        }
+        layer_info->outputs.push_back(node->outputs()[0]->debugName());
+
+        auto layer_param = std::make_shared<ReshapeLayerParam>();
+	std::cout << "reshape input 1 type = " << node->inputs().at(0)->type()->repr_str() << std::endl;
+        const auto shapes = getValue<std::vector<int64_t>>(node->inputs()[1]);
+        layer_param->num_axes = static_cast<int>(shapes.size());
+        for (const auto &shape : shapes) {
+            layer_param->shape.emplace_back((int) shape);
+        }
+	std::cout << "reshape shapes size = " << shapes.size() << std::endl;
+
+        layer_info->param = layer_param;
+
+        ADD_INPUTS_AND_OUTPUTS;
+
+        net_structure->layers.push_back(layer_info);
+
+        return TNN_OK;
+    }
+};
+
 class ListTorchConverter : public TorchOpConverter {
 public:
     bool IsSupported(const torch::jit::Node *node) {
@@ -1182,16 +1216,19 @@ REGISTER_TORCH_OP_CONVERTER(Pool, aten, adaptive_avg_pool2d)
 REGISTER_TORCH_OP_CONVERTER(Pool, aten, max_pool2d)
 REGISTER_TORCH_OP_CONVERTER(Relu, aten, relu)
 REGISTER_TORCH_OP_CONVERTER(Relu, aten, relu_)
+REGISTER_TORCH_OP_CONVERTER(Reshape, aten, reshape)
+REGISTER_TORCH_OP_CONVERTER(Reshape, aten, view)
 REGISTER_TORCH_OP_CONVERTER(Sigmoid, aten, sigmoid)
 REGISTER_TORCH_OP_CONVERTER(Size, aten, size)
 REGISTER_TORCH_OP_CONVERTER(Softmax, aten, softmax)
-// REGISTER_TORCH_OP_CONVERTER(Split, aten, split)
+REGISTER_TORCH_OP_CONVERTER(Split, aten, split)
 REGISTER_TORCH_OP_CONVERTER(StridedSlice, aten, slice)
 REGISTER_TORCH_OP_CONVERTER(To, aten, to)
 REGISTER_TORCH_OP_CONVERTER(Unsqueeze, aten, unsqueeze)
 
+
 REGISTER_TORCH_OP_CONVERTER(List, prim, ListConstruct)
-// REGISTER_TORCH_OP_CONVERTER(ListUnpack, prim, ListUnpack)
+REGISTER_TORCH_OP_CONVERTER(ListUnpack, prim, ListUnpack)
 
 // REGISTER_TORCH_OP_CONVERTER(QuantConv2D, quantized, conv2d)
 

--- a/source/tnn/network/torch/torch_op_converter.cc
+++ b/source/tnn/network/torch/torch_op_converter.cc
@@ -899,6 +899,81 @@ public:
     }
 };
 
+class SizeTorchConverter : public TorchOpConverter {
+public:
+    bool IsSupported(const torch::jit::Node *node) {
+        return true;
+    }
+    Status Convert(const torch::jit::Node *node, NetStructure *net_structure, NetResource *net_resource) {
+	std::cout << "enter size c" << std::endl;
+	// generate shape layer
+        {
+            std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
+            layer_info->type = LAYER_SHAPE;
+            layer_info->type_str = "Shape";
+            layer_info->name = node->output(0)->debugName() + "_shape";
+
+            layer_info->inputs.push_back(node->inputs()[0]->debugName());
+            layer_info->outputs.push_back(node->outputs()[0]->debugName() + "_shape");
+
+            layer_info->param = std::make_shared<LayerParam>();
+
+            ADD_INPUTS_AND_OUTPUTS;
+
+            net_structure->layers.push_back(layer_info);
+        }
+
+        // generate gather layer
+        {
+            std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
+            layer_info->type = LAYER_GATHER;
+            layer_info->type_str = "Gather";
+            layer_info->name = node->output(0)->debugName() + "_gather";
+
+            layer_info->inputs.push_back(node->inputs()[0]->debugName() + "_shape");
+            layer_info->outputs.push_back(node->outputs()[0]->debugName() + "_gather");
+
+            auto layer_param = std::make_shared<GatherLayerParam>();
+            layer_param->axis = 0;
+            layer_param->indices_in_resource = true;
+
+            layer_info->param = layer_param;
+
+            const auto indices = getValue(node->inputs()[1]);
+            auto layer_res = std::make_shared<GatherLayerResource>();
+            layer_res->indices = indices;
+
+            ADD_INPUTS_AND_OUTPUTS;
+
+            net_structure->layers.push_back(layer_info);
+            net_resource->resource_map[layer_info->name] = layer_res;
+        }
+
+        // generate unsqueeze layer
+        {
+            std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
+            layer_info->type = LAYER_UNSQUEEZE;
+            layer_info->type_str = "Unsqueeze";
+            layer_info->name = node->output(0)->debugName();
+
+            layer_info->inputs.push_back(node->inputs()[0]->debugName() + "_gather");
+            layer_info->outputs.push_back(node->outputs()[0]->debugName());
+
+            auto layer_param = std::make_shared<UnsqueezeLayerParam>();
+            layer_param->axes = {0};
+
+            layer_info->param = layer_param;
+
+            ADD_INPUTS_AND_OUTPUTS;
+
+            net_structure->layers.push_back(layer_info);
+        }
+
+	std::cout << "enter size is ok" << std::endl;
+        return TNN_OK;
+    }
+};
+
 // func: aten::softmax.int(Tensor self, int dim, ScalarType? dtype=None) -> Tensor
 //       aten::softmax.Dimname(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor, NOT SUPPORTED NOW
 //       dtype NOT SUPPORTED NOW.
@@ -916,6 +991,42 @@ public:
 
         auto layer_param = std::make_shared<SoftmaxLayerParam>();
         layer_param->axis = static_cast<int>(getValue<int64_t>(node->inputs()[1]));
+        layer_info->param = layer_param;
+
+        ADD_INPUTS_AND_OUTPUTS;
+
+        net_structure->layers.push_back(layer_info);
+
+        return TNN_OK;
+    }
+};
+
+// func: split.Tensor(Tensor(a -> *) self, int split_size, int dim=0) -> Tensor(a)[]
+class SplitTorchConverter : public TorchOpConverter {
+public:
+    bool IsSupported(const torch::jit::Node *node) {
+        if (node->outputs().at(0)->node()->kind() == c10::prim::ListUnpack) {
+            return true;
+        }
+        return true;
+    }
+
+    Status Convert(const torch::jit::Node *node, NetStructure *net_structure, NetResource *net_resource) {
+        std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
+        layer_info->type = LAYER_SPLITTORCH;
+        layer_info->type_str = "SplitTorch";
+        layer_info->name = node->output(0)->debugName();
+
+        layer_info->inputs.push_back(node->inputs()[0]->debugName());
+        // auto unpack_node = node->output()->uses()[0].user;
+        auto unpack_node = node->next();
+	for (const auto output : unpack_node->outputs()) {
+            layer_info->outputs.push_back(output->debugName());
+        }
+
+        auto layer_param = std::make_shared<SplitTorchLayerParam>();
+        layer_param->split_size = static_cast<int>(getValue<int64_t>(node->inputs()[1]));
+        layer_param->axis = static_cast<int>(getValue<int64_t>(node->inputs()[2]));
         layer_info->param = layer_param;
 
         ADD_INPUTS_AND_OUTPUTS;
@@ -963,6 +1074,63 @@ public:
 
 class ListTorchConverter : public TorchOpConverter {
 public:
+    bool IsSupported(const torch::jit::Node *node) {
+        after_size_layer_ = false;
+        for (const auto& input: node->inputs()) {
+            if (input->node()->kind() == c10::aten::size) {
+                after_size_layer_ = true;
+                break;
+            }
+        }
+	// std::cout << "after_size_layer_ = " << after_size_layer_ << std::endl;
+        return after_size_layer_;
+    }
+
+    Status Convert(const torch::jit::Node *node, NetStructure *net_structure, NetResource *net_resource) {
+	std::cout << "xxx before list if " << std::endl;
+	std::cout << "after_size_layer_ = " << after_size_layer_ << std::endl << std::endl;
+        if (after_size_layer_) {
+            std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
+            layer_info->type                      = LAYER_CONCAT;
+            layer_info->type_str                  = "Concat";
+            layer_info->name                      = node->output(0)->debugName();
+	
+	    std::cout << "enter if" << std::endl;
+            const auto inputs      = node->inputs();
+            const auto tensor_list = inputs[0];
+            for (const auto input : inputs) {
+                layer_info->inputs.push_back(input->debugName());
+            }
+            layer_info->outputs.push_back(node->outputs()[0]->debugName());
+
+            auto layer_param  = std::make_shared<ConcatLayerParam>();
+            layer_param->axis = 0;
+            layer_info->param = layer_param;
+
+	    std::cout << std::endl << std::endl << std::endl;
+	    for (const auto& input: inputs) {
+                std::cout << "xxxxxx "  << input->type()->repr_str() << std::endl;
+            }
+
+            ADD_INPUTS_AND_OUTPUTS;
+
+            net_structure->layers.push_back(layer_info);
+        }
+
+        return TNN_OK;
+    }
+
+private:
+    bool after_size_layer_ = false;
+};
+
+class ListUnpackTorchConverter : public TorchOpConverter {
+public:
+    bool IsSupported(const torch::jit::Node *node) {
+        return true;
+	return node->inputs().at(0)->node()->kind() == c10::aten::split;
+    }
+
     Status Convert(const torch::jit::Node *node, NetStructure *net_structure, NetResource *net_resource) {
         return TNN_OK;
     }
@@ -1015,14 +1183,18 @@ REGISTER_TORCH_OP_CONVERTER(Pool, aten, max_pool2d)
 REGISTER_TORCH_OP_CONVERTER(Relu, aten, relu)
 REGISTER_TORCH_OP_CONVERTER(Relu, aten, relu_)
 REGISTER_TORCH_OP_CONVERTER(Sigmoid, aten, sigmoid)
+REGISTER_TORCH_OP_CONVERTER(Size, aten, size)
 REGISTER_TORCH_OP_CONVERTER(Softmax, aten, softmax)
+// REGISTER_TORCH_OP_CONVERTER(Split, aten, split)
 REGISTER_TORCH_OP_CONVERTER(StridedSlice, aten, slice)
 REGISTER_TORCH_OP_CONVERTER(To, aten, to)
 REGISTER_TORCH_OP_CONVERTER(Unsqueeze, aten, unsqueeze)
 
 REGISTER_TORCH_OP_CONVERTER(List, prim, ListConstruct)
+// REGISTER_TORCH_OP_CONVERTER(ListUnpack, prim, ListUnpack)
 
 // REGISTER_TORCH_OP_CONVERTER(QuantConv2D, quantized, conv2d)
 
 } // namespace conversion
 }
+

--- a/source/tnn/network/torch/torch_op_converter.cc
+++ b/source/tnn/network/torch/torch_op_converter.cc
@@ -987,7 +987,7 @@ public:
     Status Convert(const torch::jit::Node *node, NetStructure *net_structure, NetResource *net_resource) {
         std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
         layer_info->type = LAYER_SOFTMAX;
-        layer_info->type_str = "Softmax";
+        layer_info->type_str = "SoftmaxCaffe";
         layer_info->name = node->output(0)->debugName();
 
         // https://pytorch.org/docs/stable/generated/torch.nn.Softmax.html?highlight=softmax#torch.nn.Softmax
@@ -1111,6 +1111,66 @@ public:
     }
 };
 
+// func: addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+class AddmmTorchConverter : public TorchOpConverter {
+public:
+    Status Convert(const torch::jit::Node *node, NetStructure *net_structure, NetResource *net_resource) {
+        std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
+        layer_info->type                      = LAYER_INNER_PRODUCT;
+        layer_info->type_str                  = "InnerProduct";
+        layer_info->name                      = node->output(0)->debugName();
+
+        const auto &inputs = node->inputs();
+
+        std::cout << "addmm input = ";
+        for (const auto &item : inputs) {
+            std::cout << item->debugName() << " ";
+        }
+        std::cout << std::endl;
+
+        layer_info->inputs.push_back(node->inputs()[1]->debugName());
+        layer_info->outputs.push_back(node->outputs()[0]->debugName());
+
+        auto layer_param  = std::make_shared<InnerProductLayerParam>();
+        auto layer_res    = new (InnerProductLayerResource);
+        const auto weight = inputs[2];
+        const auto bias   = inputs[0];
+
+        auto weight_buf = getValue(weight);
+        auto shape      = weight_buf.GetBufferDims();
+        weight_buf.Permute(shape[0], shape[1]);
+
+        std::cout << "addmm shape = ";
+        for (const auto item : shape) {
+            std::cout << item << " ";
+        }
+        std::cout << std::endl;
+
+        // set param accroding to real value, just test here
+        layer_param->name       = layer_info->name;
+        layer_param->num_output = shape[1];
+        layer_param->axis       = 1;
+
+        layer_res->name          = layer_info->name;
+        layer_res->weight_handle = weight_buf;
+
+        auto bias_buf = getValue(bias);
+        if (bias_buf.GetBytesSize() != 0) {
+            layer_param->has_bias  = 1;
+            layer_res->bias_handle = bias_buf;
+        }
+
+        layer_info->param = layer_param;
+
+        net_structure->layers.push_back(layer_info);
+        net_resource->resource_map[layer_info->name] = std::shared_ptr<LayerResource>(layer_res);
+
+        ADD_INPUTS_AND_OUTPUTS;
+
+        return TNN_OK;
+    }
+};
+
 class TransposeTorchConverter : public TorchOpConverter {
 public:
     Status Convert(const torch::jit::Node *node, NetStructure *net_structure, NetResource *net_resource) {
@@ -1229,6 +1289,7 @@ public:
 // };
 
 
+REGISTER_TORCH_OP_CONVERTER(Addmm, aten, addmm)
 REGISTER_TORCH_OP_CONVERTER(AvgPool, aten, avg_pool2d)
 REGISTER_TORCH_OP_CONVERTER(BatchNorm, aten, batch_norm)
 REGISTER_TORCH_OP_CONVERTER(Binary, aten, add_)

--- a/source/tnn/network/torch/torch_op_converter.cc
+++ b/source/tnn/network/torch/torch_op_converter.cc
@@ -909,14 +909,14 @@ public:
         }
         return true;
     }
+
     Status Convert(const torch::jit::Node *node, NetStructure *net_structure, NetResource *net_resource) {
-	std::cout << "enter size c" << std::endl;
-	// generate shape layer
+        // generate shape layer
         {
             std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
-            layer_info->type = LAYER_SHAPE;
-            layer_info->type_str = "Shape";
-            layer_info->name = node->output(0)->debugName() + "_shape";
+            layer_info->type                      = LAYER_SHAPE;
+            layer_info->type_str                  = "Shape";
+            layer_info->name                      = node->output(0)->debugName() + "_shape";
 
             layer_info->inputs.push_back(node->inputs()[0]->debugName());
             layer_info->outputs.push_back(node->outputs()[0]->debugName() + "_shape");
@@ -931,21 +931,21 @@ public:
         // generate gather layer
         {
             std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
-            layer_info->type = LAYER_GATHER;
-            layer_info->type_str = "Gather";
-            layer_info->name = node->output(0)->debugName() + "_gather";
+            layer_info->type                      = LAYER_GATHER;
+            layer_info->type_str                  = "Gather";
+            layer_info->name                      = node->output(0)->debugName() + "_gather";
 
             layer_info->inputs.push_back(node->outputs()[0]->debugName() + "_shape");
             layer_info->outputs.push_back(node->outputs()[0]->debugName() + "_gather");
 
-            auto layer_param = std::make_shared<GatherLayerParam>();
-            layer_param->axis = 0;
+            auto layer_param                 = std::make_shared<GatherLayerParam>();
+            layer_param->axis                = 0;
             layer_param->indices_in_resource = true;
 
             layer_info->param = layer_param;
 
             const auto indices = getValue(node->inputs()[1]);
-            auto layer_res = std::make_shared<GatherLayerResource>();
+            auto layer_res     = std::make_shared<GatherLayerResource>();
             layer_res->indices = indices;
 
             ADD_INPUTS_AND_OUTPUTS;
@@ -957,14 +957,14 @@ public:
         // generate unsqueeze layer
         {
             std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
-            layer_info->type = LAYER_UNSQUEEZE;
-            layer_info->type_str = "Unsqueeze";
-            layer_info->name = node->output(0)->debugName();
+            layer_info->type                      = LAYER_UNSQUEEZE;
+            layer_info->type_str                  = "Unsqueeze";
+            layer_info->name                      = node->output(0)->debugName();
 
             layer_info->inputs.push_back(node->outputs()[0]->debugName() + "_gather");
             layer_info->outputs.push_back(node->outputs()[0]->debugName());
 
-            auto layer_param = std::make_shared<UnsqueezeLayerParam>();
+            auto layer_param  = std::make_shared<UnsqueezeLayerParam>();
             layer_param->axes = {0};
 
             layer_info->param = layer_param;
@@ -974,7 +974,6 @@ public:
             net_structure->layers.push_back(layer_info);
         }
 
-	std::cout << "enter size is ok" << std::endl;
         return TNN_OK;
     }
 };
@@ -1081,25 +1080,22 @@ public:
 class ReshapeTorchConverter : public TorchOpConverter {
 public:
     Status Convert(const torch::jit::Node *node, NetStructure *net_structure, NetResource *net_resource) {
-	std::cout << "enter reshape" << std::endl;
-	std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
-        layer_info->type = LAYER_RESHAPE;
-        layer_info->type_str = "Reshape";
-        layer_info->name = node->output(0)->debugName();
+        std::shared_ptr<LayerInfo> layer_info = std::make_shared<LayerInfo>();
+        layer_info->type                      = LAYER_RESHAPE;
+        layer_info->type_str                  = "Reshape";
+        layer_info->name                      = node->output(0)->debugName();
 
-        for (const auto& input : node->inputs()) {
+        for (const auto &input : node->inputs()) {
             layer_info->inputs.push_back(input->debugName());
         }
         layer_info->outputs.push_back(node->outputs()[0]->debugName());
 
-        auto layer_param = std::make_shared<ReshapeLayerParam>();
-	std::cout << "reshape input 1 type = " << node->inputs().at(0)->type()->repr_str() << std::endl;
-        const auto shapes = getValue<std::vector<int64_t>>(node->inputs()[1]);
+        auto layer_param      = std::make_shared<ReshapeLayerParam>();
+        const auto shapes     = getValue<std::vector<int64_t>>(node->inputs()[1]);
         layer_param->num_axes = static_cast<int>(shapes.size());
         for (const auto &shape : shapes) {
-            layer_param->shape.emplace_back((int) shape);
+            layer_param->shape.emplace_back((int)shape);
         }
-	std::cout << "reshape shapes size = " << shapes.size() << std::endl;
 
         layer_info->param = layer_param;
 
@@ -1122,12 +1118,6 @@ public:
 
         const auto &inputs = node->inputs();
 
-        std::cout << "addmm input = ";
-        for (const auto &item : inputs) {
-            std::cout << item->debugName() << " ";
-        }
-        std::cout << std::endl;
-
         layer_info->inputs.push_back(node->inputs()[1]->debugName());
         layer_info->outputs.push_back(node->outputs()[0]->debugName());
 
@@ -1139,12 +1129,6 @@ public:
         auto weight_buf = getValue(weight);
         auto shape      = weight_buf.GetBufferDims();
         weight_buf.Permute(shape[0], shape[1]);
-
-        std::cout << "addmm shape = ";
-        for (const auto item : shape) {
-            std::cout << item << " ";
-        }
-        std::cout << std::endl;
 
         // set param accroding to real value, just test here
         layer_param->name       = layer_info->name;
@@ -1216,8 +1200,6 @@ public:
     }
 
     Status Convert(const torch::jit::Node *node, NetStructure *net_structure, NetResource *net_resource) {
-	std::cout << "xxx before list if " << std::endl;
-	// std::cout << "after_size_layer_ = " << after_size_layer_ << std::endl << std::endl;
         auto input_type = node->input(0)->type();
         if (input_type->kind() == c10::TypeKind::TensorType) {
             return TNN_OK;
@@ -1228,8 +1210,7 @@ public:
             layer_info->type                      = LAYER_CONCAT;
             layer_info->type_str                  = "Concat";
             layer_info->name                      = node->output(0)->debugName();
-	
-	    std::cout << "enter if" << std::endl;
+
             const auto inputs      = node->inputs();
             const auto tensor_list = inputs[0];
             for (const auto input : inputs) {
@@ -1241,9 +1222,7 @@ public:
             layer_param->axis = 0;
             layer_info->param = layer_param;
 
-	    std::cout << std::endl << std::endl << std::endl;
-	        for (const auto& input: inputs) {
-                std::cout << "xxxxxx "  << input->type()->repr_str() << std::endl;
+            for (const auto &input : inputs) {
                 auto const_buf = getValue(input);
                 if (const_buf.GetBytesSize() > 0) {
                     if (*(const_buf.force_to<int *>()) != INT_MAX) {

--- a/source/tnn/network/torch/torch_op_converter.cc
+++ b/source/tnn/network/torch/torch_op_converter.cc
@@ -902,6 +902,11 @@ public:
 class SizeTorchConverter : public TorchOpConverter {
 public:
     bool IsSupported(const torch::jit::Node *node) {
+        for (int i = 0; i < node->output()->uses().size(); i++) {
+            if (node->output()->uses()[i].user->kind() != at::prim::ListConstruct) {
+                return false;
+            }
+        }
         return true;
     }
     Status Convert(const torch::jit::Node *node, NetStructure *net_structure, NetResource *net_resource) {

--- a/source/tnn/network/torch/torch_op_converter.h
+++ b/source/tnn/network/torch/torch_op_converter.h
@@ -117,13 +117,13 @@ static RawBuffer getValue(const torch::jit::Value* value) {
     if (value_kind != c10::TypeKind::TensorType) {
         if (value_kind == c10::TypeKind::FloatType) {
             const auto data = getValue<float>(value);
-            return RawBuffer(4, (char*)(&data), {1});
+            return RawBuffer(4, (char*)(&data), {});
         } else if (value_kind == c10::TypeKind::IntType) {
             int64_t data_int64 = getValue<int64_t>(value);
             data_int64 = std::max(data_int64, static_cast<int64_t>(INT_MIN));
             data_int64 = std::min(data_int64, static_cast<int64_t>(INT_MAX));
             int data = static_cast<int>(data_int64);
-            RawBuffer buf = RawBuffer(4, (char*)(&data), {1});
+            RawBuffer buf = RawBuffer(4, (char*)(&data), {});
             buf.SetDataType(DATA_TYPE_INT32);
             return buf;
         } else if (value_kind == c10::TypeKind::NoneType) {

--- a/source/tnn/network/torch/torch_op_converter.h
+++ b/source/tnn/network/torch/torch_op_converter.h
@@ -117,13 +117,13 @@ static RawBuffer getValue(const torch::jit::Value* value) {
     if (value_kind != c10::TypeKind::TensorType) {
         if (value_kind == c10::TypeKind::FloatType) {
             const auto data = getValue<float>(value);
-            return RawBuffer(4, (char*)(&data), {});
+            return RawBuffer(4, (char*)(&data), {1});
         } else if (value_kind == c10::TypeKind::IntType) {
             int64_t data_int64 = getValue<int64_t>(value);
             data_int64 = std::max(data_int64, static_cast<int64_t>(INT_MIN));
             data_int64 = std::min(data_int64, static_cast<int64_t>(INT_MAX));
             int data = static_cast<int>(data_int64);
-            RawBuffer buf = RawBuffer(4, (char*)(&data), {});
+            RawBuffer buf = RawBuffer(4, (char*)(&data), {1});
             buf.SetDataType(DATA_TYPE_INT32);
             return buf;
         } else if (value_kind == c10::TypeKind::NoneType) {

--- a/source/tnn/network/torch/torch_tnn_engine.cc
+++ b/source/tnn/network/torch/torch_tnn_engine.cc
@@ -15,7 +15,7 @@ bool TorchConvertCtx::dealPrime(const torch::jit::Node *node) {
     std::string opType = node->kind().toUnqualString();
     switch (node->kind()) {
         case at::prim::Constant:
-        case at::prim::ListConstruct:
+        // case at::prim::ListConstruct:
         case at::prim::ListUnpack:
             for (const auto output : node->outputs()) {
                 declareVar(output->debugName(), node);
@@ -33,7 +33,7 @@ bool TorchConvertCtx::dealPrime(const torch::jit::Node *node) {
     if (opType == "Loop") {
         return true;
     }
-    return true;
+    return false;
 }
 
 int TorchConvertCtx::declareTensor(std::string name) {


### PR DESCRIPTION
1. 添加aten::size，用shape，gather和unsqueeze拼起来，运行时const folder
2. split和permute根据torch的规则，增加了v2的layer type，acc部分可复用原来的
3. partition部分如果是非计算密集型子图则删除