### PR TITLE
[FIX] fix cuda roialign roi_cols; fix strided_slice_v2 dim build; fix…

### DIFF
--- a/source/tnn/device/cuda/acc/cuda_roialign_layer_acc.cu
+++ b/source/tnn/device/cuda/acc/cuda_roialign_layer_acc.cu
@@ -164,7 +164,7 @@ Status CudaRoiAlignLayerAcc::Forward(const std::vector<Blob *> &inputs, const st
     int pooled_width = param->output_width;
     float spatial_scale = param->spatial_scale;
     int sampling_ratio = param->sampling_ratio;
-    int roi_cols = batch_indices_blob->GetBlobDesc().dims[0];
+    int roi_cols = rois_blob->GetBlobDesc().dims[1];
     float *input_data = static_cast<float *>(input_blob->GetHandle().base);
     float *input_rois = static_cast<float *>(rois_blob->GetHandle().base);
     int *batch_indices_ptr = static_cast<int *>(batch_indices_blob->GetHandle().base);

--- a/source/tnn/network/tensorrt/layer_builder/roialign_layer_builder.cc
+++ b/source/tnn/network/tensorrt/layer_builder/roialign_layer_builder.cc
@@ -23,8 +23,8 @@ bool RoiAlignTRTPluginLayerBuilder::supportsFormatCombination(
     if (!(nbInputs == 3 && nbOutputs == 1 && pos < nbInputs + nbOutputs)) return false;
     switch (pos) {
         case 0: return inOut[pos].type == nvinfer1::DataType::kFLOAT;
-        case 1: return inOut[pos].type == nvinfer1::DataType::kINT32;
-        case 2: return inOut[pos].type == nvinfer1::DataType::kFLOAT;
+        case 1: return inOut[pos].type == nvinfer1::DataType::kFLOAT;
+        case 2: return inOut[pos].type == nvinfer1::DataType::kINT32;
         case 3: return inOut[pos].type == nvinfer1::DataType::kFLOAT;
         default: return false;
     }

--- a/source/tnn/network/tensorrt/layer_builder/strided_slice_v2_layer_builder.cc
+++ b/source/tnn/network/tensorrt/layer_builder/strided_slice_v2_layer_builder.cc
@@ -69,8 +69,8 @@ ILayer* StrideSliceV2TRTLayerBuilder::AddToNetwork(INetworkDefinition* network) 
     InferOutputShape();
     DimsVector end_dim(param->ends);
     auto dim = output_blobs_[0]->GetBlobDesc().dims;
-    for (int i = 0; i < dim.size(); i++) {
-        if (end_dim[i] == INT_MAX) end_dim[i] = param->begins[i] + dim[i];
+    for (int i = 0; i < param->axes.size(); i++) {
+        if (end_dim[param->axes[i]] == INT_MAX) end_dim[param->axes[i]] = param->begins[param->axes[i]] + dim[param->axes[i]];
     }
     axes = ShapeTensor(1, std::move(param->axes));
     strides = ShapeTensor(1, std::move(param->strides));


### PR DESCRIPTION
cuda_roialign_layer_acc.cu 修复了 roi_cols 的大小，对齐到 naive
修复 roialign_layer_builder 里 input datatype
修复 strided_slice_v2 层在 dim 不全的情况下预处理 INT_MAX 的逻辑
