### PR TITLE
Update split_utils.cc

### DIFF
--- a/source/tnn/utils/split_utils.cc
+++ b/source/tnn/utils/split_utils.cc
@@ -160,7 +160,7 @@ Status SplitUtils::SplitStr(const char *str, str_arr &subs_array, const char spl
         if (c == 0 || (!quote_start && strchr(spliter, c))) {
             subs[0] = 0;
 #if defined(WIN32) && _MSC_VER < 1300  // VC++ 6.0
-            int len = min((i - cursor), subs_length - 1);
+            int len =  (i - cursor)>=(subs_length - 1)?(subs_length - 1):(i - cursor);
 #else
             int len = std::min<int>(i - cursor, subs_length - 1);
 #endif


### PR DESCRIPTION
我使用mingw32编译提示错误，因为使用mingw32编译器仍然需要空间命名
[ 99%] Building CXX object CMakeFiles/TNN.dir/source/tnn/utils/split_utils.cc.obj
D:\TNN\source\tnn\utils\split_utils.cc: In static member function 'static tnn::Status tnn::SplitUtils::SplitStr(const char*, tnn::str_arr&, const char*, bool, bool, bool, bool, bool)':
D:\TNN\source\tnn\utils\split_utils.cc:163:23: error: 'min' was not declared in this scope
             int len = min((i - cursor), subs_length - 1);
个人认为修改这样更好一下，可以适应mingw32和兼顾之前的编译器