### PR TITLE
[opencl][fix] try save program cache

### DIFF
--- a/source/tnn/device/opencl/opencl_blob_converter.cc
+++ b/source/tnn/device/opencl/opencl_blob_converter.cc
@@ -104,6 +104,9 @@ Status OpenCLBlobConverterAcc::ConvertToMatAsync(Mat &mat, MatConvertParam param
             return ret;
         }
         convert_to_mat_map_[to_mat_key] = unit;
+        //only try save once, ignore fail
+        auto opencl_runtime   = OpenCLRuntime::GetInstance();
+        opencl_runtime->SaveProgramCache();
     }
 
     OpenCLExecuteUnit unit = convert_to_mat_map_[to_mat_key];

--- a/source/tnn/device/opencl/opencl_context.cc
+++ b/source/tnn/device/opencl/opencl_context.cc
@@ -158,10 +158,6 @@ Status OpenCLContext::OnInstanceForwardBegin() {
 }
 
 Status OpenCLContext::OnInstanceForwardEnd() {
-    Status ret = opencl_runtime_->SaveProgramCache();
-    if (ret != TNN_OK) {
-        LOGE("save program cache failed, ret: %d, msg: %s\n", (int)ret, ret.description().c_str());
-    }
     return TNN_OK;
 }
 

--- a/source/tnn/device/opencl/opencl_runtime.cc
+++ b/source/tnn/device/opencl/opencl_runtime.cc
@@ -612,10 +612,15 @@ Status OpenCLRuntime::SaveProgramCache() {
             auto program_name = key.first;
             auto build_option = key.second;
             struct ProgramCacheInfo info;
-            RETURN_VALUE_ON_NEQ(program_name.size() < PROGRAM_NAME_MAX_LEN, true,
-                                TNNERR_OUTOFMEMORY);
-            RETURN_VALUE_ON_NEQ(build_option.size() < BUILD_OPTION_MAX_LEN, true,
-                                TNNERR_OUTOFMEMORY);
+            if(program_name.size() >= PROGRAM_NAME_MAX_LEN) {
+                ret = Status(TNNERR_OUTOFMEMORY, "check program name size error");
+                continue;
+            }
+
+            if(build_option.size() >= BUILD_OPTION_MAX_LEN) {
+                ret = Status(TNNERR_OUTOFMEMORY, "check build option size error");
+                continue;
+            }
             strcpy(info.program_name, program_name.c_str());
             strcpy(info.build_option, build_option.c_str());
 
@@ -628,8 +633,10 @@ Status OpenCLRuntime::SaveProgramCache() {
                     kernel_key_list_stream << kernel_name << " ";
                 }
             }
-            RETURN_VALUE_ON_NEQ(kernel_key_list_stream.str().size() < KERNEL_KEY_LIST_MAX_LEN, true,
-                                TNNERR_OUTOFMEMORY);
+            if(kernel_key_list_stream.str().size() >= KERNEL_KEY_LIST_MAX_LEN) {
+                ret = Status(TNNERR_OUTOFMEMORY, "check kernel key list stream size error");
+                continue;
+            }
             strcpy(info.kernel_key_list, kernel_key_list_stream.str().c_str());
             info.buffer_size = buffer_size;
             int fwsize = fwrite(&info, sizeof(struct ProgramCacheInfo), 1, program_cache_fout);


### PR DESCRIPTION
当前方案问题：如果保存失败，每次forward都会触发保存逻辑，并且有泄漏问题。
修复方案核心：仅在构建ConvertToMat kernel阶段保存一次，解决kernel不保存引发的加载性能问题，同时对于保存失败场景，不会每次推理都尝试保存。