### PR TITLE
[CONVERTER][BUG]1. fix issue 1595;

### DIFF
--- a/tools/converter/source/tflite/tflite_converter.cc
+++ b/tools/converter/source/tflite/tflite_converter.cc
@@ -82,6 +82,8 @@ TNN_NS::Status TFLite2Tnn::Convert2Tnn(TNN_NS::NetStructure& net_structure, TNN_
                 LOGE("The model conflict between same input names %s\n", name.c_str());
                 return TNN_NS::TNNERR_CONVERT_INVALID_MODEL;
             }
+            // insert input blob net_structure
+            net_structure.blobs.insert(name);
         }
 
         // set output
@@ -97,6 +99,8 @@ TNN_NS::Status TFLite2Tnn::Convert2Tnn(TNN_NS::NetStructure& net_structure, TNN_
                 LOGE("The model conflict between same output names %s\n", name.c_str());
                 return TNN_NS::TNNERR_CONVERT_INVALID_MODEL;
             }
+            // insert output blob for net_structure
+            net_structure.blobs.insert(name);
         }
         // convert layer
         auto& layers = net_structure.layers;


### PR DESCRIPTION
1. fix issue #1595 
2. 出现 bug 的原因是：当一层有激活函数是，SeparateActivation 方法将激活层和原始层分割开，但是InsertBlobs 添加了最后一层（也就是激活层）的输入和输出，如果激活层之前的操作没有添加到 blob 中，该层的信息就会丢失。