### PR TITLE
[TEST] remove redundant test cases in `test_softmax_layer`

### DIFF
--- a/test/unit_test/layer_test/test_softmax_layer.cc
+++ b/test/unit_test/layer_test/test_softmax_layer.cc
@@ -24,7 +24,7 @@ class SoftmaxLayerTest : public LayerTest,
                          public ::testing::WithParamInterface<std::tuple<int, int, int, int, int, int, DataType>> {};
 
 INSTANTIATE_TEST_SUITE_P(LayerTest, SoftmaxLayerTest,
-                         ::testing::Combine(testing::Values(1, 2), testing::Values(10, 12, 10, 12, 512),
+                         ::testing::Combine(testing::Values(1, 2), testing::Values(10, 12, 512),
                                             testing::Values(10, 512), testing::Values(1, 10, 512),
                                             // axis
                                             testing::Values(-1, 0, 1, 2, 3, 4),


### PR DESCRIPTION
1. channel的测试值有重复