### PR TITLE
Fix multithread read-write-race issue of ModelInterpreter

### DIFF
--- a/source/tnn/interpreter/ncnn/ncnn_model_interpreter.cc
+++ b/source/tnn/interpreter/ncnn/ncnn_model_interpreter.cc
@@ -165,7 +165,7 @@ namespace ncnn {
     Status NCNNModelInterpreter::AppendCommonLayer(
             str_arr& layer_cfg_arr,
             NetStructure *structure,
-            std::map<std::string, std::shared_ptr<AbstractLayerInterpreter>> &layer_interpreter_map) {
+            const safe_map<std::string, std::shared_ptr<AbstractLayerInterpreter>> &layer_interpreter_map) {
         Status ret = TNN_OK;
         auto cur_layer = std::make_shared<LayerInfo>();
         // 0.LayerType;1.layer_name;2.input_count;3.output_count
@@ -209,7 +209,7 @@ namespace ncnn {
 
         // 3. Create Layer interpreter
         auto layer_interpreter = layer_interpreter_map[type_str];
-        if (layer_interpreter == NULL) {
+        if (layer_interpreter == nullptr) {
             LOGET("layer %s not supported\n", "ncnn", type_str.c_str());
             return Status(TNNERR_INVALID_NETCFG, "nill interpreter");
         }
@@ -268,7 +268,7 @@ namespace ncnn {
 
             // 0. Create Layer interpreter
             auto layer_interpreter = layer_interpreter_map[type_str];
-            if (layer_interpreter == NULL) {
+            if (layer_interpreter == nullptr) {
                 LOGET("layer %s not supported\n", "ncnn", type_str.c_str());
                 return Status(TNNERR_INVALID_NETCFG, "nill interpreter");
             }
@@ -291,14 +291,18 @@ namespace ncnn {
 
     Status NCNNModelInterpreter::RegisterLayerInterpreter(std::string type_name,
                                                           AbstractLayerInterpreter *interpreter) {
-        auto &layer_interpreter_map      = GetLayerInterpreterMap();
+        auto &layer_interpreter_map      = LayerInterpreterMap();
         layer_interpreter_map[type_name] = std::shared_ptr<AbstractLayerInterpreter>(interpreter);
         return TNN_OK;
     }
 
-    std::map<std::string, std::shared_ptr<AbstractLayerInterpreter>> &NCNNModelInterpreter::GetLayerInterpreterMap() {
-        static std::map<std::string, std::shared_ptr<AbstractLayerInterpreter>> layer_interpreter_map;
+    safe_map<std::string, std::shared_ptr<AbstractLayerInterpreter>> &NCNNModelInterpreter::LayerInterpreterMap() {
+        static safe_map<std::string, std::shared_ptr<AbstractLayerInterpreter>> layer_interpreter_map;
         return layer_interpreter_map;
+    }
+
+    const safe_map<std::string, std::shared_ptr<AbstractLayerInterpreter>> &NCNNModelInterpreter::GetLayerInterpreterMap() {
+        return LayerInterpreterMap();
     }
 
 }  // namespace ncnn

--- a/source/tnn/interpreter/ncnn/ncnn_model_interpreter.h
+++ b/source/tnn/interpreter/ncnn/ncnn_model_interpreter.h
@@ -19,6 +19,7 @@
 #include <vector>
 #include <algorithm>
 #include "tnn/interpreter/default_model_interpreter.h"
+#include "tnn/utils/safe_map.h"
 
 namespace TNN_NS {
 
@@ -39,7 +40,7 @@ namespace ncnn {
         static Status RegisterLayerInterpreter(std::string type_name, AbstractLayerInterpreter* creator);
 
         // @brief get layer interpreter by layer type
-        static std::map<std::string, std::shared_ptr<AbstractLayerInterpreter>>& GetLayerInterpreterMap();
+        static const safe_map<std::string, std::shared_ptr<AbstractLayerInterpreter>>& GetLayerInterpreterMap();
 
     private:
         Status InterpretProto(std::string &content);
@@ -47,10 +48,13 @@ namespace ncnn {
         Status InterpretInput();
         Status AppendCommonLayer(
             str_arr& layer_cfg_arr, NetStructure *structure,
-            std::map<std::string, std::shared_ptr<AbstractLayerInterpreter>> &layer_interpreter_map);
+            const safe_map<std::string, std::shared_ptr<AbstractLayerInterpreter>> &layer_interpreter_map);
 
         Status FindOutputs();
         Status Convert(shared_ptr<LayerInfo> cur_layer, std::vector<std::shared_ptr<LayerInfo>> output_layers);
+
+        // @brief get layer interpreter by layer type
+        static safe_map<std::string, std::shared_ptr<AbstractLayerInterpreter>>& LayerInterpreterMap();
     };
 
 }  // namespace ncnn

--- a/source/tnn/interpreter/tnn/model_interpreter.cc
+++ b/source/tnn/interpreter/tnn/model_interpreter.cc
@@ -360,7 +360,7 @@ Status ModelInterpreter::InterpretLayer(const std::string &layer_str) {
 
     LayerParam *param      = NULL;
     auto layer_interpreter = layer_interpreter_map[type];
-    if (layer_interpreter != NULL) {
+    if (layer_interpreter != nullptr) {
         layer_interpreter->InterpretProto(layer_cfg_arr, out_end, &param);
     }
 
@@ -435,7 +435,7 @@ Status ModelInterpreter::InterpretModel(std::string &model_content) {
         LayerResource *layer_resource = NULL;
         auto layer_interpreter        = layer_interpreter_map[ly_head.type_];
         // refactor later, layer_interpreter NULL return error_code.
-        if (layer_interpreter != NULL) {
+        if (layer_interpreter != nullptr) {
             Status result = layer_interpreter->InterpretResource(*deserializer, &layer_resource);
             if (result != TNN_OK) {
                 return result;
@@ -476,13 +476,17 @@ Status ModelInterpreter::InterpretModel(std::string &model_content) {
 }
 
 Status ModelInterpreter::RegisterLayerInterpreter(LayerType type, AbstractLayerInterpreter *interpreter) {
-    std::map<LayerType, std::shared_ptr<AbstractLayerInterpreter>> &layer_interpreter_map = GetLayerInterpreterMap();
+    safe_map<LayerType, std::shared_ptr<AbstractLayerInterpreter>> &layer_interpreter_map = LayerInterpreterMap();
     layer_interpreter_map[type] = std::shared_ptr<AbstractLayerInterpreter>(interpreter);
     return TNN_OK;
 }
 
-std::map<LayerType, std::shared_ptr<AbstractLayerInterpreter>> &ModelInterpreter::GetLayerInterpreterMap() {
-    static std::map<LayerType, std::shared_ptr<AbstractLayerInterpreter>> layer_interpreter_map;
+const safe_map<LayerType, std::shared_ptr<AbstractLayerInterpreter>> &ModelInterpreter::GetLayerInterpreterMap() {
+    return LayerInterpreterMap();
+}
+
+safe_map<LayerType, std::shared_ptr<AbstractLayerInterpreter>> &ModelInterpreter::LayerInterpreterMap() {
+    static safe_map<LayerType, std::shared_ptr<AbstractLayerInterpreter>> layer_interpreter_map;
     return layer_interpreter_map;
 }
 

--- a/source/tnn/interpreter/tnn/model_interpreter.h
+++ b/source/tnn/interpreter/tnn/model_interpreter.h
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include "tnn/interpreter/default_model_interpreter.h"
 #include "tnn/interpreter/tnn/objseri.h"
+#include "tnn/utils/safe_map.h"
 
 using namespace TNN_NS;
 namespace TNN_NS {
@@ -104,10 +105,14 @@ public:
     static Status RegisterLayerInterpreter(LayerType type, AbstractLayerInterpreter* creator);
 
     // @brief get layer interpreter by layer type
-    static std::map<LayerType, std::shared_ptr<AbstractLayerInterpreter>>& GetLayerInterpreterMap();
+    static const safe_map<LayerType, std::shared_ptr<AbstractLayerInterpreter>>& GetLayerInterpreterMap();
 
     // @brief copy interpreter
     virtual std::shared_ptr<AbstractModelInterpreter> Copy();
+
+private:
+    // @brief get layer interpreter by layer type
+    static safe_map<LayerType, std::shared_ptr<AbstractLayerInterpreter>>& LayerInterpreterMap();
 
 protected:
     virtual Status InterpretProto(std::string& content);

--- a/source/tnn/utils/safe_map.h
+++ b/source/tnn/utils/safe_map.h
@@ -1,0 +1,111 @@
+// Tencent is pleased to support the open source community by making TNN available.
+//
+// Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef TNN_SOURCE_UTILS_THREAD_SAFE_MAP_H_
+#define TNN_SOURCE_UTILS_THREAD_SAFE_MAP_H_
+
+#include <memory>
+#include <map>
+#include <mutex>
+#include <thread>
+#include <condition_variable>
+#include <atomic>
+
+#include "tnn/core/common.h"
+#include "tnn/core/macro.h"
+
+namespace TNN_NS {
+
+
+template < class Key, class T, class Compare  =  std::less<Key>, class Alloc  =  std::allocator<std::pair<const Key,T> > > 
+class safe_map : public std::map<Key, T, Compare, Alloc>
+{
+private:
+    typedef typename std::map<Key, T, Compare, Alloc>::iterator iterator;
+    typedef typename std::map<Key, T, Compare, Alloc>::const_iterator const_iterator;
+    typedef typename std::map<Key, T, Compare, Alloc>::key_type key_type;
+    typedef typename std::map<Key, T, Compare, Alloc>::key_compare key_compare;
+    typedef typename std::map<Key, T, Compare, Alloc>::allocator_type allocator_type;
+    typedef typename std::map<Key, T, Compare, Alloc>::value_type value_type;
+    typedef typename std::map<Key, T, Compare, Alloc>::mapped_type mapped_type;
+    typedef typename std::map<Key, T, Compare, Alloc>::size_type size_type;
+    typedef typename std::map<Key, T, Compare, Alloc> map;
+    
+public:
+    explicit safe_map (const key_compare& comp  =  key_compare(), 
+                              const allocator_type& alloc  =  allocator_type()) : std::map<Key, T, Compare, Alloc>(comp,alloc) {}
+
+    explicit safe_map (const allocator_type& alloc) : std::map<Key, T, Compare, Alloc>(alloc) {}
+
+    template <class InputIterator> 
+    safe_map (InputIterator first, InputIterator last,
+                    const key_compare& comp  =  key_compare(), const allocator_type& alloc  =  allocator_type()) : std::map<Key, T, Compare, Alloc>
+                    (first, last, comp, alloc) {}
+
+    safe_map (const map& x) : std::map<Key, T, Compare, Alloc>(x) {}
+    safe_map (const safe_map& x) : std::map<Key, T, Compare, Alloc>(x) {}
+    safe_map (const safe_map& x, const allocator_type& alloc) : std::map<Key, T, Compare, Alloc>(x, alloc) {}
+    safe_map (map&& x) : std::map<Key, T, Compare, Alloc>(x) {}
+    safe_map (safe_map&& x) : std::map<Key, T, Compare, Alloc>(x) {}
+    safe_map (map&& x, const allocator_type& alloc) : std::map<Key, T, Compare, Alloc>(x, alloc) {}
+    safe_map (safe_map&& x, const allocator_type& alloc) : std::map<Key, T, Compare, Alloc>(x, alloc) {}
+
+    safe_map (std::initializer_list<value_type> il, const key_compare& comp  =  key_compare(), 
+                     const allocator_type& alloc  =  allocator_type()) : std::map<Key, T, Compare, Alloc>(il, comp, alloc) {}
+
+    safe_map<Key, T, Compare, Alloc>& operator =  (const map& x) {
+        std::map<Key, T, Compare, Alloc>::operator = (x);
+        return (*this);
+    }
+
+    safe_map<Key, T, Compare, Alloc>& operator =  (const safe_map<Key, T, Compare, Alloc>& x) {
+        std::map<Key, T, Compare, Alloc>::operator = (x);
+        return (*this);
+    }
+
+    safe_map<Key, T, Compare, Alloc>& operator =  (map&& x) {
+        std::map<Key, T, Compare, Alloc>::operator = (x);
+        return (*this);
+    }
+
+    safe_map<Key, T, Compare, Alloc>& operator =  (safe_map<Key, T, Compare, Alloc>&& x) {
+        std::map<Key, T, Compare, Alloc>::operator = (x);
+        return (*this);
+    }
+
+    safe_map<Key, T, Compare, Alloc>& operator =  (std::initializer_list<value_type> il) {
+        std::map<Key, T, Compare, Alloc>::operator = (il);
+        return (*this);
+    }
+
+    mapped_type& operator[] (const key_type& k) {
+        return std::map<Key, T, Compare, Alloc>::operator[](k);
+    }
+
+    const mapped_type operator[] (const key_type& k) const {
+        auto it = std::map<Key, T, Compare, Alloc>::find(k);
+        if (it == std::map<Key, T, Compare, Alloc>::end()) {
+            return mapped_type();
+        }
+        return it->second;
+    }
+
+    mapped_type& operator[] (key_type&& k) {
+        return std::map<Key, T, Compare, Alloc>::operator[](k);
+    }
+};
+
+} // namespace TNN_NS
+
+#endif //TNN_SOURCE_UTILS_THREAD_SAFE_MAP_H_


### PR DESCRIPTION
Interpreter change from std::map to safe_map, later one offers a const operator[] function