### PR TITLE
Optimize dynamic range quantize

### DIFF
--- a/platforms/android/model_check_android.sh
+++ b/platforms/android/model_check_android.sh
@@ -20,6 +20,7 @@ OPTION_DUMP_OUTPUT=""
 OPTION_CHECK_BATCH=
 OPTION_CHECK_OUTPUT=
 SET_PRECISION=
+REFERENCE_PATH=""
 OPTION_REFERENCE_FILE=""
 
 function usage() {
@@ -133,6 +134,13 @@ function run_android() {
             echo "push input file"
             $ADB push ${INPUT_PATH} ${ANDROID_DATA_DIR}/input.txt
         fi
+        # push reference file
+        if [ -n "$REFERENCE_PATH" ]
+        then
+            echo "push reference file"
+            $ADB push ${REFERENCE_PATH} ${ANDROID_DATA_DIR}/reference.txt
+            OPTION_REFERENCE_FILE=" -f ${ANDROID_DATA_DIR}/reference.txt "
+        fi
         TEST_MODEL_PATH=${TEST_PROTO_PATH/proto/model}
         $ADB push ${TEST_PROTO_PATH} ${ANDROID_DATA_DIR}/test.tnnproto
         $ADB push ${TEST_MODEL_PATH} ${ANDROID_DATA_DIR}/test.tnnmodel
@@ -213,7 +221,7 @@ while [ "$1" != "" ]; do
             ;;
         -f)
             shift
-            OPTION_REFERENCE_FILE=" -f $1"
+            REFERENCE_PATH="$1"
             shift
             ;;
         -do)

--- a/source/tnn/device/arm/acc/convolution/arm_conv_layer_acc.cc
+++ b/source/tnn/device/arm/acc/convolution/arm_conv_layer_acc.cc
@@ -31,7 +31,8 @@ Status ArmConvLayerAcc::Init(Context *context, LayerParam *param, LayerResource 
     ConvLayerResource *conv_res = dynamic_cast<ConvLayerResource *>(resource);
     CHECK_PARAM_NULL(conv_res);
 
-    if (conv_res->filter_handle.GetDataType() == DATA_TYPE_HALF) {
+    if (conv_res->filter_handle.GetDataType() == DATA_TYPE_HALF
+        || conv_res->bias_handle.GetDataType() == DATA_TYPE_HALF) {
         LayerResource *fp32_res = nullptr;
         RETURN_ON_NEQ(ConvertHalfResource(LAYER_CONVOLUTION, conv_res, &fp32_res), TNN_OK);
         conv_acc_f32_resource_ = std::shared_ptr<LayerResource>(fp32_res);

--- a/tools/dynamic_range_quantization/dynamic_range_quantization.h
+++ b/tools/dynamic_range_quantization/dynamic_range_quantization.h
@@ -48,8 +48,6 @@ private:
     Status PerChannelQuant(RawBuffer& weight_buf, RawBuffer& quant_buf, RawBuffer& scale_buf, int num_kernel);
     Status PerTensorQuant(RawBuffer& weight_buf, RawBuffer& quant_buf, RawBuffer& scale_buf);
 
-    float GetAbsMax(float* data, int data_size);
-
     std::shared_ptr<NetStructure> net_structure_ = nullptr;
     std::shared_ptr<NetResource> net_resource_   = nullptr;
     const int bits_                              = 8;

--- a/tools/dynamic_range_quantization/utils.cc
+++ b/tools/dynamic_range_quantization/utils.cc
@@ -15,93 +15,79 @@
 #include <vector>
 
 #include "tnn/core/macro.h"
+#include "tnn/device/arm/acc/Half8.h"
 #include "tnn/interpreter/raw_buffer.h"
 namespace TNN_NS {
 
 float RANGE_BOUND = 0.6f;
 
 bool NeedPerChannelQuantize(RawBuffer& raw_buffer, const int channel_size) {
-    const int data_count = raw_buffer.GetDataCount();
-    const DataType  data_type = raw_buffer.GetDataType();
+    const int data_count     = raw_buffer.GetDataCount();
+    const DataType data_type = raw_buffer.GetDataType();
+    ASSERT(data_count % channel_size == 0);
+    int stride = data_count / channel_size;
+    std::vector<float> min_values(channel_size, std::numeric_limits<float>::max());
+    std::vector<float> max_values(channel_size, std::numeric_limits<float>::min());
     if (data_type == DATA_TYPE_FLOAT) {
-        auto data            = raw_buffer.force_to<float*>();
-        assert(data_count % channel_size == 0);
-        std::vector<float> min_values(channel_size, std::numeric_limits<float>::max());
-        std::vector<float> max_values(channel_size, std::numeric_limits<float>::min());
-        int stride = data_count / channel_size;
+        float* data = raw_buffer.force_to<float*>();
         for (int i = 0; i < channel_size; ++i) {
             for (int j = 0; j < stride; ++j) {
                 float value   = data[i * stride + j];
                 min_values[i] = std::min(min_values[i], value);
             }
-        }
-        float sum_range = 0.0f;
-        for (int i = 0; i < channel_size; ++i) {
-            sum_range += max_values[i] - min_values[i];
-        }
-        float average_range = sum_range / channel_size;
-        if (average_range > RANGE_BOUND) {
-            LOGE("The range of weights overflowed.\n");
-            return false;
         }
     } else if (data_type == DATA_TYPE_HALF) {
-        auto data            = raw_buffer.force_to<fp16_t *>();
-        assert(data_count % channel_size == 0);
-        std::vector<float> min_values(channel_size, std::numeric_limits<float>::max());
-        std::vector<float> max_values(channel_size, std::numeric_limits<float>::min());
-        int stride = data_count / channel_size;
+        fp16_t* data = raw_buffer.force_to<fp16_t*>();
         for (int i = 0; i < channel_size; ++i) {
             for (int j = 0; j < stride; ++j) {
-                float value   = data[i * stride + j];
-                min_values[i] = std::min(min_values[i], value);
+                // fp16_t -> float
+                fp16_t value  = data[i * stride + j];
+                min_values[i] = std::min(min_values[i], (float)value);
             }
         }
-        float sum_range = 0.0f;
-        for (int i = 0; i < channel_size; ++i) {
-            sum_range += max_values[i] - min_values[i];
-        }
-        float average_range = sum_range / channel_size;
-        if (average_range > RANGE_BOUND) {
-            LOGE("The range of weights overflowed.\n");
-            return false;
-        }
+    } else {
+        LOGE("NeedPerChannelQuantize does not support data type: %d", data_type);
+        return false;
+    }
+    float sum_range = 0.0f;
+    for (int i = 0; i < channel_size; ++i) {
+        sum_range += max_values[i] - min_values[i];
+    }
+    float average_range = sum_range / channel_size;
+    if (average_range > RANGE_BOUND) {
+        LOGE("The range of weights overflowed.\n");
+        return false;
     }
     return true;
 }
 
 bool NeedPerTensorQuantize(RawBuffer& raw_buffer) {
-    const int data_count = raw_buffer.GetDataCount();
-    const DataType  data_type = raw_buffer.GetDataType();
+    const int data_count     = raw_buffer.GetDataCount();
+    const DataType data_type = raw_buffer.GetDataType();
+    float min                = std::numeric_limits<float>::max();
+    float max                = std::numeric_limits<float>::min();
     if (data_type == DATA_TYPE_FLOAT) {
-        auto data            = raw_buffer.force_to<float*>();
-        float min            = std::numeric_limits<float>::max();
-        float max            = std::numeric_limits<float>::min();
+        auto data = raw_buffer.force_to<float*>();
         for (int i = 0; i < data_count; ++i) {
-            min = std::min(min, (float )data[i]);
-            max = std::max(max, (float )data[i]);
+            min = std::min(min, data[i]);
+            max = std::max(max, data[i]);
         }
-        float sum_range     = max - min;
-        float average_range = sum_range / 1;
-        if (average_range > RANGE_BOUND) {
-            LOGE("The range of weights overflowed.\n");
-            return false;
-        }
-        return true;
     } else if (data_type == DATA_TYPE_HALF) {
-        auto data            = raw_buffer.force_to<fp16_t *>();
-        float min            = std::numeric_limits<float>::max();
-        float max            = std::numeric_limits<float>::min();
+        auto data = raw_buffer.force_to<fp16_t*>();
         for (int i = 0; i < data_count; ++i) {
-            min = std::min(min, (float )data[i]);
-            max = std::max(max, (float )data[i]);
+            min = std::min(min, (float)data[i]);
+            max = std::max(max, (float)data[i]);
         }
-        float sum_range     = max - min;
-        float average_range = sum_range / 1;
-        if (average_range > RANGE_BOUND) {
-            LOGE("The range of weights overflowed.\n");
-            return false;
-        }
-        return true;
+    } else {
+        LOGE("NeedPerTensorQuantize does not support data type: %d", data_type);
+        return false;
     }
+    float sum_range     = max - min;
+    float average_range = sum_range / 1;
+    if (average_range > RANGE_BOUND) {
+        LOGE("The range of weights overflowed.\n");
+        return false;
+    }
+    return true;
 }
 }  // namespace TNN_NS

--- a/tools/dynamic_range_quantization/utils.cc
+++ b/tools/dynamic_range_quantization/utils.cc
@@ -1,0 +1,65 @@
+// Tencent is pleased to support the open source community by making TNN available.
+//
+// Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+#include <limits>
+#include <vector>
+
+#include "tnn/core/macro.h"
+#include "tnn/interpreter/raw_buffer.h"
+namespace TNN_NS {
+
+float RANGE_BOUND = 0.6f;
+
+bool NeedPerChannelQuantize(RawBuffer& raw_buffer, const int channel_size) {
+    const int data_count = raw_buffer.GetDataCount();
+    auto data            = raw_buffer.force_to<float*>();
+    assert(data_count % channel_size == 0);
+    std::vector<float> min_values(channel_size, std::numeric_limits<float>::max());
+    std::vector<float> max_values(channel_size, std::numeric_limits<float>::min());
+    int stride = data_count / channel_size;
+    for (int i = 0; i < channel_size; ++i) {
+        for (int j = 0; j < stride; ++j) {
+            float value   = data[i * stride + j];
+            min_values[i] = std::min(min_values[i], value);
+        }
+    }
+    float sum_range = 0.0f;
+    for (int i = 0; i < channel_size; ++i) {
+        sum_range += max_values[i] - min_values[i];
+    }
+    float average_range = sum_range / channel_size;
+    if (average_range > RANGE_BOUND) {
+        LOGE("The range of weights overflowed.\n");
+        return false;
+    }
+    return true;
+}
+
+bool NeedPerTensorQuantize(RawBuffer& raw_buffer) {
+    const int data_count = raw_buffer.GetDataCount();
+    auto data            = raw_buffer.force_to<float*>();
+    float min            = std::numeric_limits<float>::max();
+    float max            = std::numeric_limits<float>::min();
+    for (int i = 0; i < data_count; ++i) {
+        min = std::min(min, data[i]);
+        max = std::max(max, data[i]);
+    }
+    float sum_range     = max - min;
+    float average_range = sum_range / 1;
+    if (average_range > RANGE_BOUND) {
+        LOGE("The range of weights overflowed.\n");
+        return false;
+    }
+    return true;
+}
+}  // namespace TNN_NS

--- a/tools/dynamic_range_quantization/utils.cc
+++ b/tools/dynamic_range_quantization/utils.cc
@@ -22,44 +22,86 @@ float RANGE_BOUND = 0.6f;
 
 bool NeedPerChannelQuantize(RawBuffer& raw_buffer, const int channel_size) {
     const int data_count = raw_buffer.GetDataCount();
-    auto data            = raw_buffer.force_to<float*>();
-    assert(data_count % channel_size == 0);
-    std::vector<float> min_values(channel_size, std::numeric_limits<float>::max());
-    std::vector<float> max_values(channel_size, std::numeric_limits<float>::min());
-    int stride = data_count / channel_size;
-    for (int i = 0; i < channel_size; ++i) {
-        for (int j = 0; j < stride; ++j) {
-            float value   = data[i * stride + j];
-            min_values[i] = std::min(min_values[i], value);
+    const DataType  data_type = raw_buffer.GetDataType();
+    if (data_type == DATA_TYPE_FLOAT) {
+        auto data            = raw_buffer.force_to<float*>();
+        assert(data_count % channel_size == 0);
+        std::vector<float> min_values(channel_size, std::numeric_limits<float>::max());
+        std::vector<float> max_values(channel_size, std::numeric_limits<float>::min());
+        int stride = data_count / channel_size;
+        for (int i = 0; i < channel_size; ++i) {
+            for (int j = 0; j < stride; ++j) {
+                float value   = data[i * stride + j];
+                min_values[i] = std::min(min_values[i], value);
+            }
         }
-    }
-    float sum_range = 0.0f;
-    for (int i = 0; i < channel_size; ++i) {
-        sum_range += max_values[i] - min_values[i];
-    }
-    float average_range = sum_range / channel_size;
-    if (average_range > RANGE_BOUND) {
-        LOGE("The range of weights overflowed.\n");
-        return false;
+        float sum_range = 0.0f;
+        for (int i = 0; i < channel_size; ++i) {
+            sum_range += max_values[i] - min_values[i];
+        }
+        float average_range = sum_range / channel_size;
+        if (average_range > RANGE_BOUND) {
+            LOGE("The range of weights overflowed.\n");
+            return false;
+        }
+    } else if (data_type == DATA_TYPE_HALF) {
+        auto data            = raw_buffer.force_to<fp16_t *>();
+        assert(data_count % channel_size == 0);
+        std::vector<float> min_values(channel_size, std::numeric_limits<float>::max());
+        std::vector<float> max_values(channel_size, std::numeric_limits<float>::min());
+        int stride = data_count / channel_size;
+        for (int i = 0; i < channel_size; ++i) {
+            for (int j = 0; j < stride; ++j) {
+                float value   = data[i * stride + j];
+                min_values[i] = std::min(min_values[i], value);
+            }
+        }
+        float sum_range = 0.0f;
+        for (int i = 0; i < channel_size; ++i) {
+            sum_range += max_values[i] - min_values[i];
+        }
+        float average_range = sum_range / channel_size;
+        if (average_range > RANGE_BOUND) {
+            LOGE("The range of weights overflowed.\n");
+            return false;
+        }
     }
     return true;
 }
 
 bool NeedPerTensorQuantize(RawBuffer& raw_buffer) {
     const int data_count = raw_buffer.GetDataCount();
-    auto data            = raw_buffer.force_to<float*>();
-    float min            = std::numeric_limits<float>::max();
-    float max            = std::numeric_limits<float>::min();
-    for (int i = 0; i < data_count; ++i) {
-        min = std::min(min, data[i]);
-        max = std::max(max, data[i]);
+    const DataType  data_type = raw_buffer.GetDataType();
+    if (data_type == DATA_TYPE_FLOAT) {
+        auto data            = raw_buffer.force_to<float*>();
+        float min            = std::numeric_limits<float>::max();
+        float max            = std::numeric_limits<float>::min();
+        for (int i = 0; i < data_count; ++i) {
+            min = std::min(min, (float )data[i]);
+            max = std::max(max, (float )data[i]);
+        }
+        float sum_range     = max - min;
+        float average_range = sum_range / 1;
+        if (average_range > RANGE_BOUND) {
+            LOGE("The range of weights overflowed.\n");
+            return false;
+        }
+        return true;
+    } else if (data_type == DATA_TYPE_HALF) {
+        auto data            = raw_buffer.force_to<fp16_t *>();
+        float min            = std::numeric_limits<float>::max();
+        float max            = std::numeric_limits<float>::min();
+        for (int i = 0; i < data_count; ++i) {
+            min = std::min(min, (float )data[i]);
+            max = std::max(max, (float )data[i]);
+        }
+        float sum_range     = max - min;
+        float average_range = sum_range / 1;
+        if (average_range > RANGE_BOUND) {
+            LOGE("The range of weights overflowed.\n");
+            return false;
+        }
+        return true;
     }
-    float sum_range     = max - min;
-    float average_range = sum_range / 1;
-    if (average_range > RANGE_BOUND) {
-        LOGE("The range of weights overflowed.\n");
-        return false;
-    }
-    return true;
 }
 }  // namespace TNN_NS

--- a/tools/dynamic_range_quantization/utils.h
+++ b/tools/dynamic_range_quantization/utils.h
@@ -1,0 +1,23 @@
+// Tencent is pleased to support the open source community by making TNN available.
+//
+// Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+#include "tnn/core/macro.h"
+#include "tnn/interpreter/raw_buffer.h"
+
+namespace TNN_NS {
+
+bool NeedPerChannelQuantize(RawBuffer& raw_buffer, const int channel_size);
+
+bool NeedPerTensorQuantize(RawBuffer& raw_buffer);
+
+}  // namespace TNN_NS


### PR DESCRIPTION
1.  优化了dynamic range quantization 的逻辑，添加了根据权重分布进行过滤的逻辑；
2. dynamic range quantization 支持 fp16 的模型，进一步压缩模型大小；
3. 修复了 arm 推理 dynamic range quantization 模型（fp16， int8 模型混合）失败的 bug；
4. 修复在  model_check 中指定 reference file，但是推理时并没有实际用到的 bug； 