### PR TITLE
[METAL] fix stride slice crach when dims is 2

### DIFF
--- a/source/tnn/device/metal/acc/metal_stride_slice_v2_layer_acc.mm
+++ b/source/tnn/device/metal/acc/metal_stride_slice_v2_layer_acc.mm
@@ -167,9 +167,9 @@ Status MetalStrideSliceV2LayerAcc::ComputeThreadSize(const std::vector<Blob *> &
                                         const std::vector<Blob *> &outputs,
                                         MTLSize &size) {
        auto dims_output  = outputs[0]->GetBlobDesc().dims;
-       const auto batch  = dims_output[0];
-       const auto slice  = UP_DIV(dims_output[1], 4);
-       const auto height = dims_output[2];
+       const auto batch  = DimsFunctionUtils::GetDim(dims_output,0);
+       const auto slice  = UP_DIV(DimsFunctionUtils::GetDim(dims_output,1), 4);
+       const auto height = DimsFunctionUtils::GetDim(dims_output,2);
        const auto isize  = DimsFunctionUtils::GetDimProduct(dims_output, 3);
        size = MTLSizeMake(isize, height, batch * slice);
        return TNN_OK;


### PR DESCRIPTION
1. 修复metal的stride slice算子当维度为2时的crash