### PR TITLE
onnx convert change

### DIFF
--- a/tools/convert2tnn/onnx_converter/onnx2tnn.py
+++ b/tools/convert2tnn/onnx_converter/onnx2tnn.py
@@ -113,7 +113,9 @@ def convert(onnx_path, output_dir=None, version="v1.0", optimize=True, half=Fals
         command = command + " -input_shape " + input_names
     logging.debug("The onnx2tnn command:" + command + "\n")
 
-    work_dir = "../onnx2tnn/onnx-converter/"
+    current_file_dir = os.path.dirname(__file__)
+
+    work_dir = current_file_dir + "/../../onnx2tnn/onnx-converter/"
     result = cmd.run(command, work_dir=work_dir)
 
     if result == 0:

--- a/tools/convert2tnn/utils/align_model.py
+++ b/tools/convert2tnn/utils/align_model.py
@@ -34,8 +34,8 @@ import numpy as np
 
 def run_tnn_model_check(proto_path, model_path, input_path, reference_output_path, is_tflite=False, align_batch=False):
     cmd.run("pwd")
-    relative_path = "bin/model_check"
-    model_check_path = parse_path.parse_path(relative_path)
+    current_file_dir = os.path.dirname(__file__)
+    model_check_path = current_file_dir + "/../bin/model_check"
     checker.check_file_exist(model_check_path)
     command = model_check_path + " -e -p  " + proto_path + " -m " + \
         model_path + " -i " + input_path + " -f " + reference_output_path + " -d NAIVE"


### PR DESCRIPTION
之前实现需要cd tools/convert2tnn目录，然后运行转模型工具，不能在其他路径调用转模型工具。