### PR TITLE
Fix Bug in GridSample opencl crash and GridSample OP convertion

### DIFF
--- a/source/tnn/device/opencl/acc/opencl_gridsample_layer_acc.cc
+++ b/source/tnn/device/opencl/acc/opencl_gridsample_layer_acc.cc
@@ -80,7 +80,7 @@ Status OpenCLGridsampleLayerAcc::Reshape(const std::vector<Blob *> &inputs, cons
         LOGE("Error: layer param is null\n");
         return Status(TNNERR_MODEL_ERR, "Error: layer param is null");
     }
-    if (gridsample_param->mode != 2 || gridsample_param->pad_type != 0 || gridsample_param->align_corners != 0) {
+    if (gridsample_param->mode != 2 || gridsample_param->pad_type != 0 || (gridsample_param->align_corners != 0 && gridsample_param->align_corners != 1)) {
         return Status(TNNERR_PARAM_ERR,
                       "OpenclGridSampleLayerAcc dont support some mode or pade type or align_corners");
     }

--- a/source/tnn/device/opencl/acc/opencl_gridsample_layer_acc.cc
+++ b/source/tnn/device/opencl/acc/opencl_gridsample_layer_acc.cc
@@ -24,10 +24,11 @@ public:
 
     virtual Status Reshape(const std::vector<Blob *> &inputs, const std::vector<Blob *> &outputs) override;
 
-    virtual Status ReloadConstantBlobs(const std::vector<Blob *> &inputs,
-                                       bool only_reload_shape_differ_blob = false) override {
-        return TNN_OK;
-    }
+    // grid_sample op crash when running on opencl after grid parameter has been optimized as constant in tnnmodel.
+    // virtual Status ReloadConstantBlobs(const std::vector<Blob *> &inputs,
+                                       // bool only_reload_shape_differ_blob = false) override {
+        // return TNN_OK;
+    // }
 };
 
 Status OpenCLGridsampleLayerAcc::Init(Context *context, LayerParam *param, LayerResource *resource,

--- a/source/tnn/device/opencl/acc/opencl_gridsample_layer_acc.cc
+++ b/source/tnn/device/opencl/acc/opencl_gridsample_layer_acc.cc
@@ -48,7 +48,14 @@ Status OpenCLGridsampleLayerAcc::Init(Context *context, LayerParam *param, Layer
     // create kernel
     std::string kernel_name;
     if (gridsample_param->mode == 2) {  // bilinear
-        kernel_name = "BilinearGridSample";
+        if (gridsample_param->align_corners == 0) {  // corner align
+            kernel_name = "BilinearGridSampleCornerAlign";
+        } else if (gridsample_param->align_corners == 1) {  // center align
+            kernel_name = "BilinearGridSampleCenterAlign";
+        } else {                                                                                                                              +  56             LOGE("Not support Gridsample align_corners type: %d\n", gridsample_param->align_corners);
+            LOGE("Not support Gridsample align_corners type: %d\n", gridsample_param->align_corners);
+            return Status(TNNERR_OPENCL_ACC_INIT_ERROR, "invalid align_corners type");
+        }
     } else {
         LOGE("Not support Gridsample type: %d\n", gridsample_param->mode);
         return Status(TNNERR_OPENCL_ACC_INIT_ERROR, "invalid upsample mode");

--- a/source/tnn/device/opencl/cl/gridsample.cl
+++ b/source/tnn/device/opencl/cl/gridsample.cl
@@ -1,6 +1,231 @@
 #include "base.inc"
 
-__kernel void BilinearGridSample(GLOBAL_SIZE_2_DIMS __read_only image2d_t input, __read_only image2d_t grid,
+__kernel void BilinearGridSampleCenterAlign(GLOBAL_SIZE_2_DIMS __read_only image2d_t input, __read_only image2d_t grid,
+                                 __write_only image2d_t output, __private const int input_height,
+                                 __private const int input_width, __private const int out_height,
+                                 __private const int out_width) {
+    const int cw = get_global_id(0);
+    const int hb = get_global_id(1);
+    DEAL_NON_UNIFORM_DIM2(cw, hb);
+    const int output_w_idx       = cw % out_width;
+    const int output_c_block_idx = cw / out_width;
+    const int output_b_idx       = hb / ((out_height + 3) / 4);
+    const int output_h_idx       = hb % ((out_height + 3) / 4);
+    FLOAT4 x = RI_F(grid, SAMPLER, (int2)(output_h_idx * 2, output_b_idx * out_width + output_w_idx));
+    FLOAT4 y = RI_F(grid, SAMPLER, (int2)(output_h_idx * 2 + 1, output_b_idx * out_width + output_w_idx));
+
+    FLOAT4 ix = (x + ((FLOAT)1.0f)) * ((FLOAT)0.5f) * (input_width - ((FLOAT)1.0f));
+    FLOAT4 iy = (y + ((FLOAT)1.0f)) * ((FLOAT)0.5f) * (input_height - ((FLOAT)1.0f));
+
+    FLOAT4 ix_nw = floor(ix);
+    FLOAT4 iy_nw = floor(iy);
+
+    FLOAT4 ix_ne = ix_nw + 1;
+    FLOAT4 iy_ne = iy_nw;
+
+    FLOAT4 ix_sw = ix_nw;
+    FLOAT4 iy_sw = iy_nw + 1;
+
+    FLOAT4 ix_se = ix_nw + 1;
+    FLOAT4 iy_se = iy_nw + 1;
+
+    // get nw_within_bound
+    int4 low_ix_nw = (int4)(ix_nw.x >= 0 ? -1 : 0, ix_nw.y >= 0 ? -1 : 0, ix_nw.z >= 0 ? -1 : 0, ix_nw.w >= 0 ? -1 : 0);
+    int4 low_iy_nw = (int4)(iy_nw.x >= 0 ? -1 : 0, iy_nw.y >= 0 ? -1 : 0, iy_nw.z >= 0 ? -1 : 0, iy_nw.w >= 0 ? -1 : 0);
+
+    int4 up_ix_nw = (int4)(ix_nw.x < input_width ? -1 : 0, ix_nw.y < input_width ? -1 : 0,
+                           ix_nw.z < input_width ? -1 : 0, ix_nw.w < input_width ? -1 : 0);
+    int4 up_iy_nw = (int4)(iy_nw.x < input_height ? -1 : 0, iy_nw.y < input_height ? -1 : 0,
+                           iy_nw.z < input_height ? -1 : 0, iy_nw.w < input_height ? -1 : 0);
+
+    int4 nw_within_bound = select((int4)(0, 0, 0, 0), (int4)(-1, -1, -1, -1), low_ix_nw);
+    nw_within_bound      = select((int4)(0, 0, 0, 0), nw_within_bound, low_iy_nw);
+    nw_within_bound      = select((int4)(0, 0, 0, 0), nw_within_bound, up_ix_nw);
+    nw_within_bound      = select((int4)(0, 0, 0, 0), nw_within_bound, up_iy_nw);
+
+    // get ne_within_bound
+    low_ix_nw = (int4)(ix_ne.x >= 0 ? -1 : 0, ix_ne.y >= 0 ? -1 : 0, ix_ne.z >= 0 ? -1 : 0, ix_ne.w >= 0 ? -1 : 0);
+    low_iy_nw = (int4)(iy_ne.x >= 0 ? -1 : 0, iy_ne.y >= 0 ? -1 : 0, iy_ne.z >= 0 ? -1 : 0, iy_ne.w >= 0 ? -1 : 0);
+    up_ix_nw  = (int4)(ix_ne.x < input_width ? -1 : 0, ix_ne.y < input_width ? -1 : 0, ix_ne.z < input_width ? -1 : 0,
+                      ix_ne.w < input_width ? -1 : 0);
+    up_iy_nw = (int4)(iy_ne.x < input_height ? -1 : 0, iy_ne.y < input_height ? -1 : 0, iy_ne.z < input_height ? -1 : 0,
+                      iy_ne.w < input_height ? -1 : 0);
+    int4 ne_within_bound = select((int4)(0, 0, 0, 0), (int4)(-1, -1, -1, -1), low_ix_nw);
+    ne_within_bound      = select((int4)(0, 0, 0, 0), ne_within_bound, low_iy_nw);
+    ne_within_bound      = select((int4)(0, 0, 0, 0), ne_within_bound, up_ix_nw);
+    ne_within_bound      = select((int4)(0, 0, 0, 0), ne_within_bound, up_iy_nw);
+
+    // get sw_within_bound
+    low_ix_nw = (int4)(ix_sw.x >= 0 ? -1 : 0, ix_sw.y >= 0 ? -1 : 0, ix_sw.z >= 0 ? -1 : 0, ix_sw.w >= 0 ? -1 : 0);
+    low_iy_nw = (int4)(iy_sw.x >= 0 ? -1 : 0, iy_sw.y >= 0 ? -1 : 0, iy_sw.z >= 0 ? -1 : 0, iy_sw.w >= 0 ? -1 : 0);
+    up_ix_nw  = (int4)(ix_sw.x < input_width ? -1 : 0, ix_sw.y < input_width ? -1 : 0, ix_sw.z < input_width ? -1 : 0,
+                      ix_sw.w < input_width ? -1 : 0);
+    up_iy_nw = (int4)(iy_sw.x < input_height ? -1 : 0, iy_sw.y < input_height ? -1 : 0, iy_sw.z < input_height ? -1 : 0,
+                      iy_sw.w < input_height ? -1 : 0);
+    int4 sw_within_bound = select((int4)(0, 0, 0, 0), (int4)(-1, -1, -1, -1), low_ix_nw);
+    sw_within_bound      = select((int4)(0, 0, 0, 0), sw_within_bound, low_iy_nw);
+    sw_within_bound      = select((int4)(0, 0, 0, 0), sw_within_bound, up_ix_nw);
+    sw_within_bound      = select((int4)(0, 0, 0, 0), sw_within_bound, up_iy_nw);
+
+    // get se_within_bound
+    low_ix_nw = (int4)(ix_se.x >= 0 ? -1 : 0, ix_se.y >= 0 ? -1 : 0, ix_se.z >= 0 ? -1 : 0, ix_se.w >= 0 ? -1 : 0);
+    low_iy_nw = (int4)(iy_se.x >= 0 ? -1 : 0, iy_se.y >= 0 ? -1 : 0, iy_se.z >= 0 ? -1 : 0, iy_se.w >= 0 ? -1 : 0);
+    up_ix_nw  = (int4)(ix_se.x < input_width ? -1 : 0, ix_se.y < input_width ? -1 : 0, ix_se.z < input_width ? -1 : 0,
+                      ix_se.w < input_width ? -1 : 0);
+    up_iy_nw = (int4)(iy_se.x < input_height ? -1 : 0, iy_se.y < input_height ? -1 : 0, iy_se.z < input_height ? -1 : 0,
+                      iy_se.w < input_height ? -1 : 0);
+    int4 se_within_bound = select((int4)(0, 0, 0, 0), (int4)(-1, -1, -1, -1), low_ix_nw);
+    se_within_bound      = select((int4)(0, 0, 0, 0), se_within_bound, low_iy_nw);
+    se_within_bound      = select((int4)(0, 0, 0, 0), se_within_bound, up_ix_nw);
+    se_within_bound      = select((int4)(0, 0, 0, 0), se_within_bound, up_iy_nw);
+
+    FLOAT4 nw = (ix_se - ix) * (iy_se - iy);
+    FLOAT4 ne = (ix - ix_sw) * (iy_sw - iy);
+    FLOAT4 sw = (ix_ne - ix) * (iy - iy_ne);
+    FLOAT4 se = (ix - ix_nw) * (iy - iy_nw);
+
+    nw = (FLOAT4)(nw_within_bound.x ? nw.x : 0, nw_within_bound.y ? nw.y : 0, nw_within_bound.z ? nw.z : 0,
+                  nw_within_bound.w ? nw.w : 0);
+    ne = (FLOAT4)(ne_within_bound.x ? ne.x : 0, ne_within_bound.y ? ne.y : 0, ne_within_bound.z ? ne.z : 0,
+                  ne_within_bound.w ? ne.w : 0);
+    sw = (FLOAT4)(sw_within_bound.x ? sw.x : 0, sw_within_bound.y ? sw.y : 0, sw_within_bound.z ? sw.z : 0,
+                  sw_within_bound.w ? sw.w : 0);
+    se = (FLOAT4)(se_within_bound.x ? se.x : 0, se_within_bound.y ? se.y : 0, se_within_bound.z ? se.z : 0,
+                  se_within_bound.w ? se.w : 0);
+    //    FLOAT4 ne = select((FLOAT)0, (ix - ix_sw) * (iy_sw - iy), ne_within_bound);
+    //    FLOAT4 sw = select((FLOAT)0, (ix_ne - ix) * (iy - iy_ne), sw_within_bound);
+    //    FLOAT4 se = select((FLOAT)0, (ix - ix_nw) * (iy - iy_nw), se_within_bound);
+
+    int nw_index_x = select(0, (int)(ix_nw.x), nw_within_bound.x);
+    int nw_index_y = select(0, (int)(iy_nw.x), nw_within_bound.x);
+    FLOAT4 res     = (FLOAT4)(0, 0, 0, 0);
+    FLOAT4 input_data_nw =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + nw_index_x, output_b_idx * input_height + nw_index_y));
+    res            = res + input_data_nw * nw.x;
+    int ne_index_x = select(0, (int)ix_ne.x, ne_within_bound.x);
+    int ne_index_y = select(0, (int)iy_ne.x, ne_within_bound.x);
+    FLOAT4 input_data_ne =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + ne_index_x, output_b_idx * input_height + ne_index_y));
+    res            = res + input_data_ne * ne.x;
+    int sw_index_x = select(0, (int)ix_sw.x, sw_within_bound.x);
+    int sw_index_y = select(0, (int)iy_sw.x, sw_within_bound.x);
+    FLOAT4 input_data_sw =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + sw_index_x, output_b_idx * input_height + sw_index_y));
+    res            = res + input_data_sw * sw.x;
+    int se_index_x = select(0, (int)ix_se.x, se_within_bound.x);
+    int se_index_y = select(0, (int)iy_se.x, se_within_bound.x);
+    FLOAT4 input_data_se =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + se_index_x, output_b_idx * input_height + se_index_y));
+    res = res + input_data_se * se.x;
+    WI_F(output, (int2)((output_c_block_idx * out_width + output_w_idx), output_b_idx * out_height + output_h_idx * 4),
+         res);
+
+    //
+    if (output_h_idx * 4 + 1 >= out_height) {
+        return;
+    }
+
+    nw_index_x = select(0, (int)(ix_nw.y), nw_within_bound.y);
+    nw_index_y = select(0, (int)(iy_nw.y), nw_within_bound.y);
+    res        = (FLOAT4)(0, 0, 0, 0);
+    input_data_nw =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + nw_index_x, output_b_idx * input_height + nw_index_y));
+    res        = res + input_data_nw * nw.y;
+    ne_index_x = select(0, (int)ix_ne.y, ne_within_bound.y);
+    ne_index_y = select(0, (int)iy_ne.y, ne_within_bound.y);
+    input_data_ne =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + ne_index_x, output_b_idx * input_height + ne_index_y));
+    res        = res + input_data_ne * ne.y;
+    sw_index_x = select(0, (int)ix_sw.y, sw_within_bound.y);
+    sw_index_y = select(0, (int)iy_sw.y, sw_within_bound.y);
+    input_data_sw =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + sw_index_x, output_b_idx * input_height + sw_index_y));
+    res        = res + input_data_sw * sw.y;
+    se_index_x = select(0, (int)ix_se.y, se_within_bound.y);
+    se_index_y = select(0, (int)iy_se.y, se_within_bound.y);
+    input_data_se =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + se_index_x, output_b_idx * input_height + se_index_y));
+    res = res + input_data_se * se.y;
+    WI_F(output,
+         (int2)((output_c_block_idx * out_width + output_w_idx), output_b_idx * out_height + output_h_idx * 4 + 1),
+         res);
+
+    //
+    if (output_h_idx * 4 + 2 >= out_height) {
+        return;
+    }
+    nw_index_x = select(0, (int)(ix_nw.z), nw_within_bound.z);
+    nw_index_y = select(0, (int)(iy_nw.z), nw_within_bound.z);
+    res        = (FLOAT4)(0, 0, 0, 0);
+    input_data_nw =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + nw_index_x, output_b_idx * input_height + nw_index_y));
+    res        = res + input_data_nw * nw.z;
+    ne_index_x = select(0, (int)ix_ne.z, ne_within_bound.z);
+    ne_index_y = select(0, (int)iy_ne.z, ne_within_bound.z);
+    input_data_ne =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + ne_index_x, output_b_idx * input_height + ne_index_y));
+    res        = res + input_data_ne * ne.z;
+    sw_index_x = select(0, (int)ix_sw.z, sw_within_bound.z);
+    sw_index_y = select(0, (int)iy_sw.z, sw_within_bound.z);
+    input_data_sw =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + sw_index_x, output_b_idx * input_height + sw_index_y));
+    res        = res + input_data_sw * sw.z;
+    se_index_x = select(0, (int)ix_se.z, se_within_bound.z);
+    se_index_y = select(0, (int)iy_se.z, se_within_bound.z);
+    input_data_se =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + se_index_x, output_b_idx * input_height + se_index_y));
+    res = res + input_data_se * se.z;
+    WI_F(output,
+         (int2)((output_c_block_idx * out_width + output_w_idx), output_b_idx * out_height + output_h_idx * 4 + 2),
+         res);
+
+    if (output_h_idx * 4 + 3 >= out_height) {
+        return;
+    }
+    nw_index_x = select(0, (int)(ix_nw.w), nw_within_bound.w);
+    nw_index_y = select(0, (int)(iy_nw.w), nw_within_bound.w);
+    res        = (FLOAT4)(0, 0, 0, 0);
+    input_data_nw =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + nw_index_x, output_b_idx * input_height + nw_index_y));
+    res        = res + input_data_nw * nw.w;
+    ne_index_x = select(0, (int)ix_ne.w, ne_within_bound.w);
+    ne_index_y = select(0, (int)iy_ne.w, ne_within_bound.w);
+    input_data_ne =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + ne_index_x, output_b_idx * input_height + ne_index_y));
+    res        = res + input_data_ne * ne.w;
+    sw_index_x = select(0, (int)ix_sw.w, sw_within_bound.w);
+    sw_index_y = select(0, (int)iy_sw.w, sw_within_bound.w);
+    input_data_sw =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + sw_index_x, output_b_idx * input_height + sw_index_y));
+    res        = res + input_data_sw * sw.w;
+    se_index_x = select(0, (int)ix_se.w, se_within_bound.w);
+    se_index_y = select(0, (int)iy_se.w, se_within_bound.w);
+    input_data_se =
+        RI_F(input, SAMPLER,
+             (int2)(output_c_block_idx * input_width + se_index_x, output_b_idx * input_height + se_index_y));
+    res = res + input_data_se * se.w;
+    WI_F(output,
+         (int2)((output_c_block_idx * out_width + output_w_idx), output_b_idx * out_height + output_h_idx * 4 + 3),
+         res);
+}
+
+
+__kernel void BilinearGridSampleCornerAlign(GLOBAL_SIZE_2_DIMS __read_only image2d_t input, __read_only image2d_t grid,
                                  __write_only image2d_t output, __private const int input_height,
                                  __private const int input_width, __private const int out_height,
                                  __private const int out_width) {

--- a/tools/onnx2tnn/src/core/layer/onnx_converter_gridsample.cc
+++ b/tools/onnx2tnn/src/core/layer/onnx_converter_gridsample.cc
@@ -9,7 +9,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
 #include "onnx_op_converter.h"
@@ -25,33 +25,32 @@ string OnnxOpConverterGridSample::TNNOpType(NodeProto &node,
 string OnnxOpConverterGridSample::TNNLayerParam(NodeProto &node,
                                                OnnxNetInfo &net_info) {
     ostringstream layer_param;
-    auto mode = get_node_attr_ai(node, "mode", net_info, 2);
-    if (mode.size() > 0 && mode[0] == 0) {
+    auto mode = get_node_attr_s(node, "mode", "bilinear");
+    if (mode.size() > 0 && mode == "bilinear") {
         //bilinear
         layer_param << "2 ";
     } else {
         LOGE("GridSample dont support mode\n");
         return "";
     }
-    
-    auto pade_type = get_node_attr_ai(node, "padding_mode", net_info, 3);
-    if (pade_type.size() > 0 && pade_type[0] == 0) {
+
+    auto pade_type = get_node_attr_s(node, "padding_mode", "zeros");
+    if (pade_type.size() > 0 && pade_type == "zeros") {
         //padding zeros
         layer_param << "0 ";
     } else {
         LOGE("GridSample dont support pade_type\n");
         return "";
     }
-    
-    auto align_corners = get_node_attr_ai(node, "align_corners", net_info, 4);
-    if (align_corners.size() > 0 && align_corners[0] == 0) {
-        //false
-        layer_param << "0 ";
+
+    auto align_corners = get_node_attr_i(node, "align_corners", 0);
+    if (0 == align_corners || 1 == align_corners) {
+        layer_param << (0 == align_corners ? "0 " : "1 ");
     } else {
         LOGE("GridSample dont support align_corners\n");
         return "";
     }
-    
+
     return layer_param.str();
 }
 

--- a/tools/onnx2tnn/src/core/layer/onnx_converter_gridsample.cc
+++ b/tools/onnx2tnn/src/core/layer/onnx_converter_gridsample.cc
@@ -45,6 +45,7 @@ string OnnxOpConverterGridSample::TNNLayerParam(NodeProto &node,
 
     auto align_corners = get_node_attr_i(node, "align_corners", 0);
     if (0 == align_corners || 1 == align_corners) {
+        // 0:false, 1:true
         layer_param << (0 == align_corners ? "0 " : "1 ");
     } else {
         LOGE("GridSample dont support align_corners\n");


### PR DESCRIPTION
1. grid_sample op crash when running forward on opencl after the grid input blob has been optimized as constant in tnnmodel.
2. If onnx simplify is used after onnx convertion, the forward will fail because the grid input blob is ignored to be set during onnx2tnn convertion.