### PR TITLE
CpuSupportInt8Dot support Apple A16;

### DIFF
--- a/source/tnn/utils/cpu_utils.cc
+++ b/source/tnn/utils/cpu_utils.cc
@@ -76,6 +76,10 @@
 #ifndef CPUFAMILY_AARCH64_FIRESTORM_ICESTORM
 #define CPUFAMILY_AARCH64_FIRESTORM_ICESTORM 0x1b588bb3
 #endif
+// Apple M2
+#ifndef CPUFAMILY_AARCH64_AVALANCHE_BLIZZARD
+#define CPUFAMILY_AARCH64_AVALANCHE_BLIZZARD 0xda33d83d
+#endif
 #endif  // TARGET_OS_IPHONE
 #endif  // __APPLE__
 
@@ -442,7 +446,8 @@ bool CpuUtils::CpuSupportFp16() {
     unsigned int cpu_family = 0;
     size_t len              = sizeof(cpu_family);
     sysctlbyname("hw.cpufamily", &cpu_family, &len, NULL, 0);
-    fp16arith = cpu_family == CPUFAMILY_AARCH64_FIRESTORM_ICESTORM;
+    fp16arith =
+        cpu_family == CPUFAMILY_AARCH64_FIRESTORM_ICESTORM || cpu_family == CPUFAMILY_AARCH64_AVALANCHE_BLIZZARD;
     LOGD("CpuUtils::CpuSupportFp16, OSX and arm64, hw.cpufamily = %x, fp16arith = %d.\n", cpu_family, fp16arith);
     return fp16arith;
 #else
@@ -474,7 +479,7 @@ bool CpuUtils::CpuSupportInt8Dot() {
     size_t len              = sizeof(cpu_family);
     sysctlbyname("hw.cpufamily", &cpu_family, &len, NULL, 0);
     int8dot = cpu_family == CPUFAMILY_ARM_LIGHTNING_THUNDER || cpu_family == CPUFAMILY_ARM_FIRESTORM_ICESTORM ||
-              cpu_family == CPUFAMILY_ARM_AVALANCHE_BLIZZARD;
+              cpu_family == CPUFAMILY_ARM_AVALANCHE_BLIZZARD || cpu_family == CPUFAMILY_ARM_EVEREST_SAWTOOTH;
     LOGD("CpuUtils::CpuSupportInt8Dot, IOS and arm64, hw.cpufamily = %x, int8dot = %d.\n", cpu_family, int8dot);
     return int8dot;
 #else
@@ -535,7 +540,7 @@ bool CpuUtils::CpuSupportInt8Dot() {
     unsigned int cpu_family = 0;
     size_t len              = sizeof(cpu_family);
     sysctlbyname("hw.cpufamily", &cpu_family, &len, NULL, 0);
-    int8dot = cpu_family == CPUFAMILY_AARCH64_FIRESTORM_ICESTORM;
+    int8dot = cpu_family == CPUFAMILY_AARCH64_FIRESTORM_ICESTORM || cpu_family == CPUFAMILY_AARCH64_AVALANCHE_BLIZZARD;
     LOGD("CpuUtils::CpuSupportInt8Dot, OSX and arm64, hw.cpufamily = %x, int8dot = %d.\n", cpu_family, int8dot);
     return int8dot;
 #else


### PR DESCRIPTION
1.  cpu_utils 中添加了对 Apple M2 的支持
2. CpuSupportInt8Dot 添加对 Apple A16 和 Apple M2 的支持
3. CpuSupportFp16 添加了对 Apple A16 的支持；